### PR TITLE
Disabled app restart in container

### DIFF
--- a/host/2.0/stretch/amd64/base.Dockerfile
+++ b/host/2.0/stretch/amd64/base.Dockerfile
@@ -31,4 +31,4 @@ ENV HOME=/home
 ENV ASPNETCORE_URLS=http://+:80
 EXPOSE 80
 
-CMD /azure-functions-host/run-host.sh
+CMD ["dotnet", "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/host/2.0/stretch/amd64/run-host.sh
+++ b/host/2.0/stretch/amd64/run-host.sh
@@ -1,9 +1,0 @@
-#! /bin/bash
-
-COUNTER=0
-while [ $COUNTER -lt 5 ]; do
-    dotnet /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll
-    echo "process exited with $?"
-    echo "restarting host process: $COUNTER"
-    let COUNTER=COUNTER+1
-done


### PR DESCRIPTION
Having the container restart on application failure is convenient while developing locally. However, on an actual deployment, it'd be better for failures to be handled by the container orchestrator (like Kubernetes) and have that decide whether the application should be restarted.