### PR TITLE
Replace apt-get with apk in alpine images

### DIFF
--- a/host/2.0/alpine/amd64/base.Dockerfile
+++ b/host/2.0/alpine/amd64/base.Dockerfile
@@ -22,8 +22,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet
 
-RUN apt-get update && \
-    apt-get install -y gnupg wget unzip && \
+RUN apk update && \
+    apk add --no-cache gnupg wget unzip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/1.0.0/Microsoft.Azure.Functions.ExtensionBundle.1.0.0.zip && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/1.0.0 && \
     unzip /Microsoft.Azure.Functions.ExtensionBundle.1.0.0.zip -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/1.0.0 && \

--- a/host/2.0/alpine/amd64/powershell.Dockerfile
+++ b/host/2.0/alpine/amd64/powershell.Dockerfile
@@ -25,8 +25,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell
 
-RUN apt-get update && \
-    apt-get install -y gnupg wget unzip && \
+RUN apk update && \
+    apk add --no-cache gnupg wget unzip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/1.0.0/Microsoft.Azure.Functions.ExtensionBundle.1.0.0.zip && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/1.0.0 && \
     unzip /Microsoft.Azure.Functions.ExtensionBundle.1.0.0.zip -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/1.0.0 && \


### PR DESCRIPTION
This fixes the following error while building the alpine images:
> apt-get: not found