### PR TITLE
NodeJS 10.x for runtime version 2.0

### DIFF
--- a/host/2.0/stretch/amd64/node.Dockerfile
+++ b/host/2.0/stretch/amd64/node.Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && \
     apt-get install -y nodejs
 


### PR DESCRIPTION
Upgrade NodeJS runtime Docker image to NodeJS 10.x.

The description on [Docker Hub for image `azure-functions/node:2.0`](https://hub.docker.com/_/microsoft-azure-functions-base) is as follows:
> the latest stable 2.0 function runtime for Linux with node 10 worker runtime. The Dockerfile can be found here

The image actually contains NodeJS 8.x. See the file _host/2.0/stretch/amd64/node.Dockerfile_: version 8 is clearly installed.