### PR TITLE
Create package folders for importing

### DIFF
--- a/host/2.0/stretch/amd64/python-context/start.sh
+++ b/host/2.0/stretch/amd64/python-context/start.sh
@@ -6,6 +6,10 @@ DIR="$(dirname $0)"
 CUSTOM_PACKAGES_PY36="$HOME/site/wwwroot/.python_packages/lib/python3.6/site-packages"
 CUSTOM_VENV_PACKAGES_PY36="$HOME/site/wwwroot/worker_venv/lib/python3.6/site-packages"
 
+# Needed to import Python packages 
+mkdir -p "$CUSTOM_PACKAGES_PY36"
+mkdir -p "$CUSTOM_VENV_PACKAGES_PY36"
+
 export PYTHONPATH=$CUSTOM_PACKAGES_PY36:$CUSTOM_VENV_PACKAGES_PY36:$PYTHONPATH
 
 echo "python == $(which python)"

--- a/host/2.0/stretch/amd64/python-context/start.sh
+++ b/host/2.0/stretch/amd64/python-context/start.sh
@@ -3,15 +3,6 @@
 # Directory name for start.sh
 DIR="$(dirname $0)"
 
-CUSTOM_PACKAGES_PY36="$HOME/site/wwwroot/.python_packages/lib/python3.6/site-packages"
-CUSTOM_VENV_PACKAGES_PY36="$HOME/site/wwwroot/worker_venv/lib/python3.6/site-packages"
-
-# Needed to import Python packages 
-mkdir -p "$CUSTOM_PACKAGES_PY36"
-mkdir -p "$CUSTOM_VENV_PACKAGES_PY36"
-
-export PYTHONPATH=$CUSTOM_PACKAGES_PY36:$CUSTOM_VENV_PACKAGES_PY36:$PYTHONPATH
-
 echo "python == $(which python)"
 echo "PYTHONPATH == $PYTHONPATH"
 


### PR DESCRIPTION
Imports fail if a started Python process is not pointing to created directories which are later populated with modules. Adding a fix to create the relevant directories on startup. 