### PR TITLE
Add kudulite Dockerfile for linux consumption

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -1,0 +1,63 @@
+FROM oryxprod/build:20190521.9 as main
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install dependencies
+RUN apt-get update \
+  && apt-get install -y vim tree --no-install-recommends \
+  && apt-get install -y tcptraceroute \
+# Install Squashfs tools for KuduLite build
+  && apt-get install -y squashfs-tools \
+  && wget -O /usr/bin/tcpping http://www.vdberg.org/~richard/tcpping \
+  && chmod 755 /usr/bin/tcpping
+
+# SQL Server gem support
+RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
+
+# Install Kudu
+RUN mkdir -p /opt/Kudu/local \
+  && chmod 755 /opt/Kudu/local \
+  && apt-get update \
+  && apt-get  install -y unzip \
+# Install pm2 and pm2-logrotate
+  && mkdir -p /home/LogFiles \
+  && chmod -R 777 /home \
+  && rm -rf /tmp/*
+
+ENV DOTNET_RUNNING_IN_CONTAINER=true
+
+# Enable correct mode for dotnet watch (only mode supported in a container)
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true
+
+# Skip extraction of XML docs - generally not useful within an image/container - helps performance
+ENV NUGET_XMLDOC_MODE=skip
+
+RUN dotnet tool install -g dotnet-aspnet-codegenerator
+ENV PATH=$PATH:/root/.dotnet/tools
+
+#Instal Kudu
+RUN cd /tmp \
+    && git clone https://github.com/Azure-App-Service/KuduLite.git \
+    && cd ./KuduLite \
+    && git checkout dev \
+    && cd ./Kudu.Services.Web \
+    && benv dotnet=2.2 dotnet publish -c Release -o /opt/Kudu \
+    && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \
+    && rm -rf /tmp/* \
+    && chmod a+rw /var/nuget \
+    && find /var/nuget -type d -exec chmod 777 {} \;
+
+COPY startup.sh /
+
+RUN chmod 777 /startup.sh
+
+RUN benv node=9 npm=6 npm install -g kudusync
+RUN benv node=9 npm=6 npm install pm2@latest -g
+
+RUN ln -s /opt/nodejs/9/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm-cli.js
+ENV PATH=$PATH:/opt/nodejs/9/bin
+
+EXPOSE 80
+
+ENTRYPOINT [ "/startup.sh" ]
+CMD [ "1002", "kudu_group", "1001", "root", "localsite" ]

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#!/usr/bin/env bash
+
+cat >/etc/motd <<EOL
+    __ __          __      __    _ __
+   / //_/_  _ ____/ /_  __/ /   (_) /____
+  / ,< / / / / __  / / / / /   / / __/ _ \
+
+ / /| / /_/ / /_/ / /_/ / /___/ / /_/  __/
+/_/ |_\__,_/\__,_/\__,_/_____/_/\__/\___/
+
+
+DEBUG CONSOLE | AZURE APP SERVICE ON LINUX
+
+Documentation: http://aka.ms/webapp-linux
+Kudu Version : 1.0.0.6
+
+EOL
+cat /etc/motd
+
+if [ $# -ne 5 ]; then
+	echo "Missing parameters; exiting"
+	exit 1
+fi
+
+if [ -z "${PORT}" ]; then
+    export PORT=80
+fi
+
+GROUP_ID=$1
+GROUP_NAME=$2
+USER_ID=$3
+USER_NAME=$4
+SITE_NAME=$5
+
+groupadd -g $GROUP_ID $GROUP_NAME
+useradd -u $USER_ID -g $GROUP_NAME $USER_NAME
+chown -R $USER_NAME:$GROUP_NAME /tmp
+
+/bin/bash -c "benv node=9 npm=6 pm2 start /opt/webssh/index.js -o /home/LogFiles/webssh/pm2.log -e /home/LogFiles/webssh/pm2.err &"
+
+export KUDU_RUN_USER="$USER_NAME"
+export HOME=/home
+export WEBSITE_SITE_NAME=$SITE_NAME
+export APPSETTING_SCM_USE_LIBGIT2SHARP_REPOSITORY=0
+export KUDU_APPPATH=/opt/Kudu
+export APPDATA=/opt/Kudu/local
+
+service ssh restart
+
+cd /opt/Kudu
+
+echo $(date) running .net core
+ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2 dotnet Kudu.Services.Web.dll

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -38,16 +38,12 @@ groupadd -g $GROUP_ID $GROUP_NAME
 useradd -u $USER_ID -g $GROUP_NAME $USER_NAME
 chown -R $USER_NAME:$GROUP_NAME /tmp
 
-/bin/bash -c "benv node=9 npm=6 pm2 start /opt/webssh/index.js -o /home/LogFiles/webssh/pm2.log -e /home/LogFiles/webssh/pm2.err &"
-
 export KUDU_RUN_USER="$USER_NAME"
 export HOME=/home
 export WEBSITE_SITE_NAME=$SITE_NAME
 export APPSETTING_SCM_USE_LIBGIT2SHARP_REPOSITORY=0
 export KUDU_APPPATH=/opt/Kudu
 export APPDATA=/opt/Kudu/local
-
-service ssh restart
 
 cd /opt/Kudu
 


### PR DESCRIPTION
We need to have our own kudulite's docker image, because this image
1. exposes port 80 and bind it to kestrel server
2. stripped off webssh

Please let me know if this is the right place to place the docker file.
If so, build.sh will be updated in the next PR.