### PR TITLE
Using localhost syntax for recent ptvsd versions

### DIFF
--- a/host/2.0/stretch/amd64/appservice/start.sh
+++ b/host/2.0/stretch/amd64/appservice/start.sh
@@ -12,7 +12,7 @@ fi
 
 if [ "$APPSVC_REMOTE_DEBUGGING" == "TRUE" ]; then
     export languageWorkers__node__arguments="--inspect=0.0.0.0:$APPSVC_TUNNEL_PORT"
-    export languageWorkers__python__arguments="-m ptvsd --server --port $APPSVC_TUNNEL_PORT"
+    export languageWorkers__python__arguments="-m ptvsd --host localhost --port $APPSVC_TUNNEL_PORT"
 fi
 
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config


### PR DESCRIPTION
Ran into an issue recently where `--server` syntax is no longer usable for recent versions of `ptvsd`. Modified to `--host localhost` instead which has the same functional behavior. 