### PR TITLE
Add kudulite in build and release process

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oryx/build:20190704.2 as main
+FROM mcr.microsoft.com/oryx/build:20190730.1 as main
 ARG BRANCH
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -1,5 +1,5 @@
-FROM oryxprod/build:20190521.9 as main
-
+FROM mcr.microsoft.com/oryx/build:20190704.2 as main
+ARG BRANCH
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install dependencies
@@ -39,7 +39,7 @@ ENV PATH=$PATH:/root/.dotnet/tools
 RUN cd /tmp \
     && git clone https://github.com/Azure-App-Service/KuduLite.git \
     && cd ./KuduLite \
-    && git checkout dev \
+    && git checkout $BRANCH \
     && cd ./Kudu.Services.Web \
     && benv dotnet=2.2 dotnet publish -c Release -o /opt/Kudu \
     && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \

--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+set -e
+
+DIR=$(dirname $0)
+ESC_SEQ="\033["
+CONSOLE_RESET=$ESC_SEQ"39;49;00m"
+COLOR_RED=$ESC_SEQ"31;01m"
+COLOR_GREEN=$ESC_SEQ"32;01m"
+COLOR_YELLOW=$ESC_SEQ"33;01m"
+COLOR_CYAN=$ESC_SEQ"36;01m"
+CONSOLE_BOLD=$ESC_SEQ"1m"
+
+# Building stretch
+ACR=azurefunctions.azurecr.io
+ACR_NAMESPACE=public/azure-functions
+
+if [ -z "$branch" ]; then
+    branch=master
+fi
+
+if [ -z "$tag" ]; then
+    tag=dev
+fi
+
+name="kudulite"
+base_dir=$DIR
+
+current_image=$ACR/$ACR_NAMESPACE/$name:$tag
+echo -e "${CONSOLE_BOLD}${COLOR_GREEN}: Building $current_image ${CONSOLE_RESET}"
+docker build --build-arg BRANCH="$branch" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
+docker push "$current_image"
+
+if ! [ -z "$CI_RUN" ]; then
+    docker system prune -f -a
+fi

--- a/kudulite/build.vsts-ci.yml
+++ b/kudulite/build.vsts-ci.yml
@@ -1,0 +1,24 @@
+queue: Hosted Ubuntu 1604
+variables:
+  dockerId: azurefunctions
+
+steps:
+- bash: |
+    # login
+    set -e
+    echo $pswd | docker login -u azurefunctions --password-stdin azurefunctions.azurecr.io
+
+  displayName: login to registry
+  continueOnError: false
+  env:
+    pswd: $(dockerPassword)
+
+- bash: |
+    set -e
+    export branch=$(Build.SourceBranchName)
+    export tag=dev
+    export CI_RUN=1
+    export RUN_TESTS=1
+    ./kudulite/build.sh
+  displayName: build images
+  continueOnError: false

--- a/kudulite/release.vsts-ci.yml
+++ b/kudulite/release.vsts-ci.yml
@@ -1,0 +1,19 @@
+queue: Hosted Ubuntu 1604
+trigger: none
+variables:
+  dockerId: azurefunctions
+
+steps:
+- bash: |
+    echo $pswd | docker login -u $(dockerId) --password-stdin $(dockerId).azurecr.io
+  displayName: login
+  continueOnError: false
+  env:
+    pswd: $(dockerPassword)
+
+- bash: |
+    export ReleaseVersion=$(ReleaseVersion)
+    export tag=dev
+    ./kudulite/tag.sh
+  displayName: tag and push images
+  continueOnError: false

--- a/kudulite/tag.sh
+++ b/kudulite/tag.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+set -e
+
+ACR=azurefunctions.azurecr.io
+ACR_NAMESPACE=public/azure-functions
+
+if [ -z "$tag" ]; then
+    tag=dev
+fi
+
+function pull_tag_push {
+    local image_to_pull=$1
+    local new_image_name=$2
+
+    docker pull $image_to_pull
+    docker tag $image_to_pull $new_image_name
+    docker push $new_image_name
+}
+
+current_base=$ACR/$ACR_NAMESPACE/kudulite
+current_image=$ACR/$ACR_NAMESPACE/kudulite:$ReleaseVersion
+
+pull_tag_push $current_base:$tag $current_image
+pull_tag_push $current_base:$tag $current_base:latest


### PR DESCRIPTION
### Update kudulite in build.sh
1. We can build a kudulite image with `./build.sh kudulite <tagname>`
2. The temporary built image will always be mcr.microsoft.com/azure-functions/kudulite:dev
3. Every release will tag the built image into
  - mcr.microsoft.com/azure-functions/kudulite:latest
  - mcr.microsoft.com/azure-functions/kudulite:$(ReleaseVersion)

### Miscellaneous
Update oryx build to 20190704.2