### PR TITLE
Pin KuduLite aspnetcore code generator to version 2.2.4

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/oryx/build:20190730.1 as main
 ARG BRANCH
+ARG NAMESPACE
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install dependencies
@@ -32,12 +33,12 @@ ENV DOTNET_USE_POLLING_FILE_WATCHER=true
 # Skip extraction of XML docs - generally not useful within an image/container - helps performance
 ENV NUGET_XMLDOC_MODE=skip
 
-RUN dotnet tool install -g dotnet-aspnet-codegenerator
+RUN dotnet tool install -g dotnet-aspnet-codegenerator --version 2.2.4
 ENV PATH=$PATH:/root/.dotnet/tools
 
 #Instal Kudu
 RUN cd /tmp \
-    && git clone https://github.com/Azure-App-Service/KuduLite.git \
+    && git clone https://github.com/$NAMESPACE/KuduLite.git \
     && cd ./KuduLite \
     && git checkout $BRANCH \
     && cd ./Kudu.Services.Web \

--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -15,6 +15,10 @@ CONSOLE_BOLD=$ESC_SEQ"1m"
 ACR=azurefunctions.azurecr.io
 ACR_NAMESPACE=public/azure-functions
 
+if [ -z "$namespace" ]; then
+    namespace="Azure-App-Service"
+fi
+
 if [ -z "$branch" ]; then
     branch=master
 fi
@@ -28,7 +32,7 @@ base_dir=$DIR
 
 current_image=$ACR/$ACR_NAMESPACE/$name:$tag
 echo -e "${CONSOLE_BOLD}${COLOR_GREEN}: Building $current_image ${CONSOLE_RESET}"
-docker build --build-arg BRANCH="$branch" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
+docker build --build-arg BRANCH="$branch" --build-arg NAMESPACE="$namespace" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
 docker push "$current_image"
 
 if ! [ -z "$CI_RUN" ]; then


### PR DESCRIPTION
Since dotnet core 3.0 is released, the dotnet-aspnet-codegenerator nuget package has the latest version of 3.0 which breaks the build.

We need to pin its version to 2.2.4 to compile kudulite project.