### PR TITLE
Add runtime versions for 3.6/3.7

### DIFF
--- a/host/2.0/stretch/amd64/python/python36.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36.Dockerfile
@@ -8,4 +8,6 @@ COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image [ "/workers/python", "/azure-functions-host/workers/python" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
+ENV FUNCTIONS_WORKER_RUNTIME_VERSION=3.6
+
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/2.0/stretch/amd64/python/python37.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37.Dockerfile
@@ -8,4 +8,6 @@ COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image [ "/workers/python", "/azure-functions-host/workers/python" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
+ENV FUNCTIONS_WORKER_RUNTIME_VERSION=3.7
+
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]


### PR DESCRIPTION
@ahmelsayed, this should fix the resolution of dependencies. If you want to try it out with your own image in the  meantime to unblock, you can run with `-e "FUNCTIONS_WORKER_RUNTIME_VERSION=3.7"`. 