### PR TITLE
Azure Functions Core Tools Node images

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Linux amd64 Tags
 | `3.0`, `3.0-node10`                       | [Dockerfile](host/3.0/buster/amd64/node/node10/node10.Dockerfile)            | Debian 10  |
 | `3.0-slim`, `3.0-node10-slim`             | [Dockerfile](host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile)       | Debian 10  |
 | `3.0-appservice`, `3.0-node10-appservice` | [Dockerfile](host/3.0/buster/amd64/node/node10/node10-appservice.Dockerfile) | Debian 10  |
+| `3.0-core-tools`, `3.0-node10-core-tools` | [Dockerfile](host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile) | Debian 9  |
 | `3.0-node12`                              | [Dockerfile](host/3.0/buster/amd64/node/node12/node12.Dockerfile)            | Debian 10  |
 | `3.0-node12-slim`                         | [Dockerfile](host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile)       | Debian 10  |
 | `3.0-node12-appservice`                   | [Dockerfile](host/3.0/buster/amd64/node/node12/node12-appservice.Dockerfile) | Debian 10  |
+| `3.0-node12-core-tools`                   | [Dockerfile](host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile) | Debian 9  |
 
 #### Powershell
 

--- a/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
@@ -1,0 +1,46 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:10
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The javascript-node image includes a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    #
+    # Install Azure Functions, .NET Core, and Azure CLI
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
+    && apt-get update \
+    && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
+    #
+    # [Optional] Update a non-root user to UID/GID if needed.
+    && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid $USER_GID $USERNAME \
+        && usermod --uid $USER_UID --gid $USER_GID $USERNAME; \
+    fi \
+    && mkdir -p /home/$USERNAME/.local/share \
+    && chown -R $USER_UID:$USER_GID /home/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Azure Functions Core Tools needs a place to save data
+ENV XDG_DATA_HOME=/home/$USERNAME/.local/share
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
@@ -1,0 +1,46 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:12
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The javascript-node image includes a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    #
+    # Install Azure Functions, .NET Core, and Azure CLI
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
+    && apt-get update \
+    && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
+    #
+    # [Optional] Update a non-root user to UID/GID if needed.
+    && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid $USER_GID $USERNAME \
+        && usermod --uid $USER_UID --gid $USER_GID $USERNAME; \
+    fi \
+    && mkdir -p /home/$USERNAME/.local/share \
+    && chown -R $USER_UID:$USER_GID /home/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Azure Functions Core Tools needs a place to save data
+ENV XDG_DATA_HOME=/home/$USERNAME/.local/share
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -65,6 +65,18 @@ steps:
 
   - bash: |
       set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(Build.SourceBranchName)-node10-core-tools
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile \
+                  host/3.0/buster/amd64/node/node10/
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: node10-core-tools
+    continueOnError: false
+
+  - bash: |
+      set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(Build.SourceBranchName)-node12
 
       docker build -t $IMAGE_NAME \
@@ -97,4 +109,16 @@ steps:
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
     displayName: node12-appservice
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(Build.SourceBranchName)-node12-core-tools
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile \
+                  host/3.0/buster/amd64/node/node12/
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: node12-core-tools
     continueOnError: false

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -97,39 +97,47 @@ steps:
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice
+      docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-slim
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice
+      docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10 $TARGET_REGISTRY/node:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim $TARGET_REGISTRY/node:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-appservice
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-core-tools
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10 $TARGET_REGISTRY/node:$(TargetVersion)-node10
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim $TARGET_REGISTRY/node:$(TargetVersion)-node10-slim
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12 $TARGET_REGISTRY/node:$(TargetVersion)-node12
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-slim $TARGET_REGISTRY/node:$(TargetVersion)-node12-slim
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-appservice-quickstart
+      docker push $TARGET_REGISTRY/node:$(TargetVersion)-core-tools
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice-quickstart
+      docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice-quickstart
+      docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
 
       docker system prune -a -f
     displayName: tag and push node images


### PR DESCRIPTION
Adding Azure Functions Core Tools v3 images for the Node 10, 12

## Discussion

The base image is `mcr.microsoft.com/vscode/devcontainers/javascript-node:10`.  It references https://github.com/microsoft/vscode-dev-containers/blob/master/containers/javascript-node-10/.devcontainer/Dockerfile image on the `vscode-dev-containers`.  Should we depend on it or should we create a new one from scratch? 

Currently, the Dockerfile is moved from the vscode dev-containers repo. These image is going to reference our images. 
* https://github.com/microsoft/vscode-dev-containers/tree/master/containers/azure-functions-node-10
* https://github.com/microsoft/vscode-dev-containers/tree/master/containers/azure-functions-node-12

The ancestor is debian 9 
https://hub.docker.com/_/debian


## Pipeline 
![image](https://user-images.githubusercontent.com/1390976/80518715-b3276280-893b-11ea-8a6b-73a8f1edacaa.png)

