### PR TITLE
Fix Nano Server Build

### DIFF
--- a/host/2.0/nanoserver/1803/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1803/dotnet.Dockerfile
@@ -26,7 +26,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     HOST_VERSION=2.0.13019
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    $BuildNumber = $Env:HOST_VERSION.split('.')[-1] `
+    $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `
     Invoke-WebRequest -OutFile host.zip https://github.com/Azure/azure-functions-host/archive/v$Env:HOST_VERSION.zip; `
     Expand-Archive host.zip .; `
     cd azure-functions-host-$Env:HOST_VERSION; `

--- a/host/2.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1809/dotnet.Dockerfile
@@ -26,7 +26,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     HOST_VERSION=2.0.13019
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    $BuildNumber = $Env:HOST_VERSION.split('.')[-1] `
+    $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `
     Invoke-WebRequest -OutFile host.zip https://github.com/Azure/azure-functions-host/archive/v$Env:HOST_VERSION.zip; `
     Expand-Archive host.zip .; `
     cd azure-functions-host-$Env:HOST_VERSION; `

--- a/host/2.0/nanoserver/1903/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1903/dotnet.Dockerfile
@@ -26,7 +26,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     HOST_VERSION=2.0.13019
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    $BuildNumber = $Env:HOST_VERSION.split('.')[-1] `
+    $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `
     Invoke-WebRequest -OutFile host.zip https://github.com/Azure/azure-functions-host/archive/v$Env:HOST_VERSION.zip; `
     Expand-Archive host.zip .; `
     cd azure-functions-host-$Env:HOST_VERSION; `

--- a/host/3.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1809/dotnet.Dockerfile
@@ -25,7 +25,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     HOST_VERSION=3.0.13142
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    $BuildNumber = $Env:HOST_VERSION.split('.')[-1] `
+    $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `
     Invoke-WebRequest -OutFile host.zip https://github.com/Azure/azure-functions-host/archive/v$Env:HOST_VERSION.zip; `
     Expand-Archive host.zip .; `
     cd azure-functions-host-$Env:HOST_VERSION; `

--- a/host/3.0/nanoserver/1903/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1903/dotnet.Dockerfile
@@ -26,7 +26,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     HOST_VERSION=3.0.13142
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    $BuildNumber = $Env:HOST_VERSION.split('.')[-1] `
+    $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `
     Invoke-WebRequest -OutFile host.zip https://github.com/Azure/azure-functions-host/archive/v$Env:HOST_VERSION.zip; `
     Expand-Archive host.zip .; `
     cd azure-functions-host-$Env:HOST_VERSION; `

--- a/host/3.0/nanoserver/1909/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1909/dotnet.Dockerfile
@@ -26,7 +26,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     HOST_VERSION=3.0.13142
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
-    $BuildNumber = $Env:HOST_VERSION.split('.')[-1] `
+    $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `
     Invoke-WebRequest -OutFile host.zip https://github.com/Azure/azure-functions-host/archive/v$Env:HOST_VERSION.zip; `
     Expand-Archive host.zip .; `
     cd azure-functions-host-$Env:HOST_VERSION; `


### PR DESCRIPTION
Fix nano server build:
Since the old build in https://github.com/Azure/azure-functions-docker/pull/235 has lost,
and it is now blocking Linux Consumption release https://github.com/Azure/azure-functions-docker/pull/241

I duplicate the PR and check if the build status will pass