### PR TITLE
Add unzip and wget to support Common-Script

### DIFF
--- a/host/3.0/buster/amd64/java/java8-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8-core-tools.Dockerfile
@@ -41,6 +41,9 @@ RUN apt-get update \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
+    # Install wget and unzip
+    && apt-get install -y wget unzip \
+    #
     # Install Azure Functions, .NET Core, and Azure CLI
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \


### PR DESCRIPTION
VSCode DevContainer proivde common script that user enables to use zsh option for example. For enabling this scenario, I'd like to add unzip and wget. These library is also usefrul for CI scenario. 

https://github.com/microsoft/vscode-dev-containers/pull/311

In the vscode-dev-container repo, they will add this script. It requires wget and unzip. 

```bash
ARG INSTALL_ZSH=true
ARG USERNAME=vscode
ARG USER_UID=1000
ARG USER_GID=$USER_UID

RUN curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/setup-script.sh \
    && /bin/bash /tmp/common-setup.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
    && rm /tmp/common-setup.sh
```