### PR TITLE
Python Core Tools and Version bump to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Linux amd64 Tags
 | `3.0-python3.8-slim`                         | [Dockerfile](host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile)       | Debian 10  |
 | `3.0-python3.8-appservice`                   | [Dockerfile](host/3.0/buster/amd64/python/python38/python38-appservice.Dockerfile) | Debian 10  |
 | `3.0-python3.8-buildenv`                     | [Dockerfile](host/3.0/buster/amd64/python/python38/python38-buildenv.Dockerfile)   | Debian 10  |
+| `3.0-python3.8-core-tools`                     | [Dockerfile](host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile)   | Debian 10  |
 
 #### Base
 

--- a/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN \
+    #
+    # Install Azure Functions, .NET Core, and Azure CLI
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
+    && apt-get update \
+    && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
+    #
+    # Install Docker CE CLI (needed for publish with --build-native-deps)
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
+    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /home/vscode/.local/share \
+    && chown -R vscode /home/vscode
+
+# Azure Functions Core Tools needs a place to save data
+ENV XDG_DATA_HOME=/home/vscode/.local/share
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -188,6 +188,7 @@ steps:
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv
+      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7 $TARGET_REGISTRY/python:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
@@ -206,6 +207,7 @@ steps:
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-quickstart
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-buildenv
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-core-tools
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
@@ -224,6 +226,7 @@ steps:
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-quickstart
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-buildenv
+      docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-core-tools
 
       docker system prune -a -f
     displayName: tag and push python images

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -6,7 +6,7 @@ pr:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/python/python37/*
+      - host/3.0/buster/amd64/python/python38/*
 
 trigger:
   branches:
@@ -14,7 +14,7 @@ trigger:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/python/python37/*
+      - host/3.0/buster/amd64/python/python38/*
 
 steps:
   - bash: |
@@ -119,6 +119,53 @@ steps:
                   host/3.0/buster/amd64/python/python37/
       docker push $IMAGE_NAME
     displayName: python3.7-buildenv
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/python/python38/python38.Dockerfile \
+                  host/3.0/buster/amd64/python/python38
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: python3.8
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8-slim
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile \
+                  host/3.0/buster/amd64/python/python38/
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: python3.8-slim
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8-appservice
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/python/python38/python38-appservice.Dockerfile \
+                  host/3.0/buster/amd64/python/python38/
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: python3.8-appservice
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8-buildenv
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/python/python38/python38-buildenv.Dockerfile \
+                  host/3.0/buster/amd64/python/python38/
+      docker push $IMAGE_NAME
+    displayName: python3.8-buildenv
     continueOnError: false
 
   - bash: |

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -120,3 +120,14 @@ steps:
       docker push $IMAGE_NAME
     displayName: python3.7-buildenv
     continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8-core-tools
+
+      docker build -t $IMAGE_NAME \
+                  -f host/3.0/buster/amd64/python/python38/python38-buildenv.Dockerfile \
+                  host/3.0/buster/amd64/python/python38/
+      docker push $IMAGE_NAME
+    displayName: python3.8-core-tools
+    continueOnError: false


### PR DESCRIPTION
I create a core tools for python.

This PR includes:
1. Core Tools image with python 3.8
2. Enable trigger for 3.8 to build python images.
3. Add pipeline code to enable 3.8 python images.

