### PR TITLE
Tag Python 3.6 as default Python image in V3

### DIFF
--- a/host/2.0/publish.yml
+++ b/host/2.0/publish.yml
@@ -30,6 +30,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice
@@ -67,6 +68,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice
@@ -106,6 +108,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node8
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node8-slim
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node8-appservice
@@ -172,6 +175,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-slim
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-appservice
@@ -206,6 +210,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice

--- a/host/2.0/python-build.yml
+++ b/host/2.0/python-build.yml
@@ -6,7 +6,7 @@ pr:
       - master
   paths:
     include:
-      - host/2.0/stretch/amd64/python/python37/*
+      - host/2.0/stretch/amd64/python/*
 
 trigger:
   branches:
@@ -14,7 +14,7 @@ trigger:
       - master
   paths:
     include:
-      - host/2.0/stretch/amd64/python/python37/*
+      - host/2.0/stretch/amd64/python/*
 
 steps:
   - bash: |

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -30,6 +30,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice
@@ -64,6 +65,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice
@@ -101,6 +103,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice
@@ -151,6 +154,7 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-slim
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-appservice
@@ -180,6 +184,11 @@ steps:
     continueOnError: false
 
   - bash: |
+      set -e
+      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6
+      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim
+      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
+      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice
@@ -190,11 +199,11 @@ steps:
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools
 
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7 $TARGET_REGISTRY/python:$(TargetVersion)
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7 $TARGET_REGISTRY/python:$(TargetVersion)-python3.7
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-slim

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -6,7 +6,7 @@ pr:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/python/python38/*
+      - host/3.0/buster/amd64/python/*
 
 trigger:
   branches:
@@ -14,7 +14,7 @@ trigger:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/python/python38/*
+      - host/3.0/buster/amd64/python/*
 
 steps:
   - bash: |


### PR DESCRIPTION
Bug:
The current V3 Pipeline is tagging Python 3.7 as the default image in V3