### PR TITLE
Fix node CI trigger paths

### DIFF
--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -6,7 +6,8 @@ pr:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/node/node8/*
+      - host/3.0/buster/amd64/node/node10/*
+      - host/3.0/buster/amd64/node/node12/*
 
 trigger:
   branches:
@@ -14,7 +15,8 @@ trigger:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/node/node8/*
+      - host/3.0/buster/amd64/node/node10/*
+      - host/3.0/buster/amd64/node/node12/*
 
 steps:
   - bash: |

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -6,8 +6,7 @@ pr:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/node/node10/*
-      - host/3.0/buster/amd64/node/node12/*
+      - host/3.0/buster/amd64/node/*
 
 trigger:
   branches:
@@ -15,8 +14,7 @@ trigger:
       - master
   paths:
     include:
-      - host/3.0/buster/amd64/node/node10/*
-      - host/3.0/buster/amd64/node/node12/*
+      - host/3.0/buster/amd64/node/*
 
 steps:
   - bash: |


### PR DESCRIPTION
The CI or master build wasn't triggering for the changes in node dockerfiles. This meant some updates were being missed.