### PR TITLE
Remove alpine Python publish step

### DIFF
--- a/host/2.0/publish.yml
+++ b/host/2.0/publish.yml
@@ -214,73 +214,62 @@ steps:
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
-      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-alpine
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice
-      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-alpine
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-buildenv
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice
-      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-alpine
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-alpine $TARGET_REGISTRY/python:$(TargetVersion)-alpine
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)-python3.6
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-slim
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-alpine $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-alpine
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-buildenv
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7 $TARGET_REGISTRY/python:$(TargetVersion)-python3.7
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-slim
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-alpine $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-alpine
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-buildenv
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8 $TARGET_REGISTRY/python:$(TargetVersion)-python3.8
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-slim
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-alpine $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-alpine
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-buildenv
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-alpine
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-slim
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-quickstart
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-alpine
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-buildenv
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-slim
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-quickstart
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-alpine
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-buildenv
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-slim
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-quickstart
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-alpine
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-buildenv
 
       docker system prune -a -f


### PR DESCRIPTION
It looks like we don't build alpine images anymore. This causes the publish steps to fail.