### PR TITLE
Fix: Python core-tools with CI improvement

### DIFF
--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -16,7 +16,9 @@ trigger:
     include:
       - host/3.0/buster/amd64/python/*
 
-steps:
+jobs:
+- job: python3.6
+  steps: 
   - bash: |
       # login
       set -e
@@ -26,7 +28,6 @@ steps:
     continueOnError: false
     env:
       pswd: $(dockerPassword)
-
   - bash: |
       set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.6
@@ -74,6 +75,18 @@ steps:
     displayName: python3.6-buildenv
     continueOnError: false
 
+- job: python3.7
+  steps:
+  - bash: |
+      # login
+      set -e
+      echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+    displayName: login to registry
+    continueOnError: false
+    env:
+      pswd: $(dockerPassword)
+
   - bash: |
       set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.7
@@ -120,6 +133,18 @@ steps:
       docker push $IMAGE_NAME
     displayName: python3.7-buildenv
     continueOnError: false
+
+- job: python3.8
+  steps:
+  - bash: |
+      # login
+      set -e
+      echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+    displayName: login to registry
+    continueOnError: false
+    env:
+      pswd: $(dockerPassword)
 
   - bash: |
       set -e

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -18,7 +18,7 @@ jobs:
 - job: python36
   displayName: python 3.6
   pool:
-    vmImage: 'Hosted Ubuntu 1604'
+    vmImage: ubuntu-16.04
   steps: 
   - bash: |
       # login
@@ -79,7 +79,7 @@ jobs:
 - job: python37
   displayName: python 3.7
   pool:
-    vmImage: 'Hosted Ubuntu 1604'
+    vmImage: ubuntu-16.04
   steps:
   - bash: |
       # login
@@ -141,7 +141,7 @@ jobs:
 - job: python38
   displayName: python 3.8
   pool:
-    vmImage: 'Hosted Ubuntu 1604'
+    vmImage: ubuntu-16.04
   steps:
   - bash: |
       # login

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -1,5 +1,3 @@
-queue: Hosted Ubuntu 1604
-
 pr:
   branches:
     include:
@@ -17,7 +15,10 @@ trigger:
       - host/3.0/buster/amd64/python/*
 
 jobs:
-- job: python3.6
+- job: python36
+  displayName: python 3.6
+  pool:
+    vmImage: 'Hosted Ubuntu 1604'
   steps: 
   - bash: |
       # login
@@ -75,7 +76,10 @@ jobs:
     displayName: python3.6-buildenv
     continueOnError: false
 
-- job: python3.7
+- job: python37
+  displayName: python 3.7
+  pool:
+    vmImage: 'Hosted Ubuntu 1604'
   steps:
   - bash: |
       # login
@@ -134,7 +138,10 @@ jobs:
     displayName: python3.7-buildenv
     continueOnError: false
 
-- job: python3.8
+- job: python38
+  displayName: python 3.8
+  pool:
+    vmImage: 'Hosted Ubuntu 1604'
   steps:
   - bash: |
       # login

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -18,7 +18,7 @@ jobs:
 - job: python36
   displayName: python 3.6
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   steps: 
   - bash: |
       # login
@@ -79,7 +79,7 @@ jobs:
 - job: python37
   displayName: python 3.7
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   steps:
   - bash: |
       # login
@@ -141,7 +141,7 @@ jobs:
 - job: python38
   displayName: python 3.8
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   steps:
   - bash: |
       # login

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -40,6 +40,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.6
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -52,6 +54,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.6-slim
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -64,6 +68,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.6-appservice
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -75,6 +81,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.6-buildenv
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
 - job: python37
   displayName: python 3.7
@@ -102,6 +110,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.7
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -114,6 +124,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.7-slim
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -126,6 +138,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.7-appservice
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -137,6 +151,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.7-buildenv
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
 - job: python38
   displayName: python 3.8
@@ -164,6 +180,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.8
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -176,6 +194,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.8-slim
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -188,6 +208,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.8-appservice
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -199,6 +221,8 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.8-buildenv
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1
 
   - bash: |
       set -e
@@ -211,3 +235,5 @@ jobs:
       docker push $IMAGE_NAME
     displayName: python3.8-core-tools
     continueOnError: false
+    env:
+      DOCKER_BUILDKIT: 1

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -173,8 +173,9 @@ steps:
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8-core-tools
 
       docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/python/python38/python38-buildenv.Dockerfile \
+                  -f host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile \
                   host/3.0/buster/amd64/python/python38/
+      npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
     displayName: python3.8-core-tools
     continueOnError: false


### PR DESCRIPTION
I found an issue that python 3.8 core-tools images is based on wrong images. 
I also find, sometimes, it causes lack of capacity. 
Refer this pipeline execution: https://azure-functions.visualstudio.com/azure-functions-docker/_build/results?buildId=1569&view=results

```
Error processing tar file(exit status 1): write /usr/lib/azure-functions-core-tools-3/workers/powershell/runtimes/linux/native/libgrpc_csharp_ext.x64.so: no space left on device
2020-05-15T00:45:47.3568743Z 
```

For fixing this I've done:
* Point the correct core-tools image and add testing (it was not there) 
* Using Jobs for parallel execution
* Upgrade ubuntu agent from 16.04 -> 18.04. The old version have opportunity to pick old slow vm.
* Use BuildKit  https://docs.docker.com/develop/develop-images/build_enhancements/

Pipeline is tested. Works fine. Now pipeline will finish in less than half.  
![image](https://user-images.githubusercontent.com/1390976/82013608-89568700-962f-11ea-9387-2fb1d9cce48b.png)


If you want condition on/off the version, I can do it. 

Please merge it. 