### PR TITLE
Remove Core Tools Build Publish

### DIFF
--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -65,17 +65,6 @@ steps:
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/java:$(Build.SourceBranchName)-java8-core-tools
-      docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile \
-                  host/3.0/buster/amd64/java/java8
-      npm run test $IMAGE_NAME --prefix  test/
-      docker push $IMAGE_NAME
-    displayName: java8-core-tools
-    continueOnError: false
-
-  - bash: |
-      set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/java:$(Build.SourceBranchName)-java11
 
       docker build -t $IMAGE_NAME \
@@ -108,16 +97,6 @@ steps:
     displayName: java11-appservice
     continueOnError: false
 
-  - bash: |
-      set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/java:$(Build.SourceBranchName)-java11-core-tools
-      docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/java/java11/java11-core-tools.Dockerfile \
-                  host/3.0/buster/amd64/java/java11
-      npm run test $IMAGE_NAME --prefix  test/
-      docker push $IMAGE_NAME
-    displayName: java11-core-tools
-    continueOnError: false
 
 
 

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -65,18 +65,6 @@ steps:
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(Build.SourceBranchName)-node10-core-tools
-
-      docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile \
-                  host/3.0/buster/amd64/node/node10/
-      npm run test $IMAGE_NAME --prefix  test/
-      docker push $IMAGE_NAME
-    displayName: node10-core-tools
-    continueOnError: false
-
-  - bash: |
-      set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(Build.SourceBranchName)-node12
 
       docker build -t $IMAGE_NAME \
@@ -111,14 +99,3 @@ steps:
     displayName: node12-appservice
     continueOnError: false
 
-  - bash: |
-      set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(Build.SourceBranchName)-node12-core-tools
-
-      docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile \
-                  host/3.0/buster/amd64/node/node12/
-      npm run test $IMAGE_NAME --prefix  test/
-      docker push $IMAGE_NAME
-    displayName: node12-core-tools
-    continueOnError: false

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -34,7 +34,6 @@ steps:
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice
-      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-core-tools
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-arm32v7
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-bionic-arm32v7
 
@@ -43,8 +42,7 @@ steps:
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-arm32v7 $TARGET_REGISTRY/dotnet:$(TargetVersion)-arm32v7
+       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-arm32v7 $TARGET_REGISTRY/dotnet:$(TargetVersion)-arm32v7
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-bionic-arm32v7 $TARGET_REGISTRY/dotnet:$(TargetVersion)-bionic-arm32v7
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/base:$(TargetVersion)
@@ -56,7 +54,6 @@ steps:
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-appservice
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice-quickstart
-      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-arm32v7
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-bionic-arm32v7
       docker push $TARGET_REGISTRY/base:$(TargetVersion)
@@ -72,12 +69,10 @@ steps:
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice
-      docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-slim
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice
-      docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-core-tools
-
+ 
       docker pull mcr.microsoft.com/java/maven:8-zulu-debian10
       docker pull mcr.microsoft.com/java/maven:11-zulu-debian10
 
@@ -90,13 +85,11 @@ steps:
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim $TARGET_REGISTRY/java:$(TargetVersion)-java8-slim
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java8-appservice
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java8-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools $TARGET_REGISTRY/java:$(TargetVersion)-java8-core-tools
 
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11 $TARGET_REGISTRY/java:$(TargetVersion)-java11
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-slim $TARGET_REGISTRY/java:$(TargetVersion)-java11-slim
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java11-appservice
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java11-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-core-tools $TARGET_REGISTRY/java:$(TargetVersion)-java11-core-tools
 
       docker tag mcr.microsoft.com/java/maven:8-zulu-debian10 $TARGET_REGISTRY/java:$(TargetVersion)-java8-build
       docker tag mcr.microsoft.com/java/maven:11-zulu-debian10 $TARGET_REGISTRY/java:$(TargetVersion)-java11-build
@@ -110,13 +103,11 @@ steps:
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-slim
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-appservice
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-appservice-quickstart
-      docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-core-tools
 
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-slim
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-appservice
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-appservice-quickstart
-      docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-core-tools
 
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-build
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-build
@@ -130,47 +121,39 @@ steps:
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice
-      docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-slim
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice
-      docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10 $TARGET_REGISTRY/node:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim $TARGET_REGISTRY/node:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-appservice
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-core-tools
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10 $TARGET_REGISTRY/node:$(TargetVersion)-node10
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim $TARGET_REGISTRY/node:$(TargetVersion)-node10-slim
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12 $TARGET_REGISTRY/node:$(TargetVersion)-node12
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-slim $TARGET_REGISTRY/node:$(TargetVersion)-node12-slim
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice-quickstart
-      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-appservice-quickstart
-      docker push $TARGET_REGISTRY/node:$(TargetVersion)-core-tools
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-appservice-quickstart
-      docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-appservice-quickstart
-      docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
 
       docker system prune -a -f
     displayName: tag and push node images
@@ -220,7 +203,6 @@ steps:
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-slim
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv
-      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools
 
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
@@ -245,7 +227,6 @@ steps:
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-quickstart
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-buildenv
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-core-tools
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
@@ -270,7 +251,6 @@ steps:
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-quickstart
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-buildenv
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-core-tools
 
       docker system prune -a -f
     displayName: tag and push python images

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -223,17 +223,3 @@ jobs:
     continueOnError: false
     env:
       DOCKER_BUILDKIT: 1
-
-  - bash: |
-      set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(Build.SourceBranchName)-python3.8-core-tools
-
-      docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile \
-                  host/3.0/buster/amd64/python/python38/
-      npm run test $IMAGE_NAME --prefix  test/
-      docker push $IMAGE_NAME
-    displayName: python3.8-core-tools
-    continueOnError: false
-    env:
-      DOCKER_BUILDKIT: 1


### PR DESCRIPTION
I'm migrating Core Tools Build / Publish to the Nightly build. 
So I separate the pipeline. I also find my old  YAML file has a bug of tagging wrong. 

Until the pipeline finished, I'd like to remove the core-tools build/publishing to avoid 
to push wrong image.  
