### PR TITLE
Implement core-tools nightly build pipeline

### DIFF
--- a/core-tools-pipeline.md
+++ b/core-tools-pipeline.md
@@ -102,4 +102,9 @@ In this case, you can ignore it and wait until the apt-get azure functions core 
 ### Pipeline has got stuck
 Sometimes, I see the issue that Azure Pipelinse stop working during pulling some images. Currently, I don't know the root cause, however, as a workaround, cancel the pipeline and execute it again after waiting for a while. Then  it will success. 
 
+### Pipeline Fails without change
+
+Sometimes Pipeline fails without any change. If you see the log, it could 500 of the Docker Registry, sometimes, network issues. If it is not caused by Dockerfile or tag images mistake, just re-run the pipeline, after waiting for a while. It could happen. Each stage is re-run separately. 
+
+
 

--- a/core-tools-pipeline.md
+++ b/core-tools-pipeline.md
@@ -1,0 +1,105 @@
+# Azure Functions Core Tools Deployment Pipeline
+
+Azure Functions Core Tools image is nightly build and deployed to the production enviornment. 
+This document explains how to operation the pipelines. 
+
+## Pipelines
+We have two pipelines for Core Tools. 
+
+### v3 Core Tools Publish
+This pipeline trigged nightly at 22:00 every night. 
+
+* [v3 Core Tools Publish (private)](https://azure-functions.visualstudio.com/azure-functions-docker/_build?definitionId=42&_a=summary)
+
+This pipeline will
+
+* Fetching the latest version of the Azure Functions Core Tools from npm package. 
+* Build and Test the images for (DotNetCore 3, Java, Node, Python) then push to the Private Registry.
+* Publish these images from the Private Registry.
+
+The pipeline has several stages. 
+
+| Stage | Responsibility |
+| ---- | ---- |
+| prepare | Fetch the latest version of Azure Functions Core Tools |
+| build | Build and Test the images and publish to the Private Docker Registry with `PrivateVersion` (e.g. 3.0.2534.3) |
+| Publish | Pull the images with `PrivateVersion` and Tag and Publish the images with `MajorVersion` (e.g. 3.0) `TargetVersion` (e.g.3.0.2534) |
+
+#### Mode
+This pipeline provide several modes. 
+
+##### Full Deployment 
+
+Execute all the pipeline that I explained above. 
+
+_Pipeline Variables_
+| Name | Value |
+| ---- | ----- |
+| BuildOnly | false |
+| PublishPrivateVersion | (empty) |
+| PublishTargetVersion | (empty) |
+| SkipProduction | false |
+
+##### Build Only 
+
+Doesn't execute publish stage. It is used if the Dockerfile is property created.
+
+_Pipeline Variables_
+| Name | Value |
+| ---- | ----- |
+| BuildOnly | true |
+| PublishPrivateVersion | (empty) |
+| PublishTargetVersion | (empty) |
+| SkipProduction | - |
+
+##### Skip Production
+
+It tags the images, however, it is not actually publishing the image to production. 
+If you want to test publish stage, this option works. 
+
+_Pipeline Variables_
+| Name | Value |
+| ---- | ----- |
+| BuildOnly | false |
+| PublishPrivateVersion | - |
+| PublishTargetVersion | - |
+| SkipProduction | true |
+
+##### Rollback 
+
+If the image is broken by some reasons, you can rollback the image by this mode. 
+This pipeline preserve 7 histories for each images for each versions. 
+
+Under the hood, this pipeline has `PrivateVersion` That is used for private repository. 
+It is consist with `TaregetVersion` + `.0` 0 will be (0 - 6). 0 Represents Sunday. 
+
+If you want to Rollback, You can specify the PrivateVersion. The last dight will be 
+the weekday (Sunday(0) - Saturday(6)). This operation will only execute `publish` stage. 
+
+_Pipeline Variables_
+| Name | Value | sample |
+| ---- | ----- | ----- |
+| BuildOnly | false | false |
+| PublishPrivateVersion | PrivateVersion | 3.0.2534.3 |
+| PublishTargetVersion | TargetVersion | 3.0.2534 |
+| SkipProduction | false | false |
+
+This pipeline will publish 3.0 version and Tareget version (e.g. 3.0.2534) to the production. 
+The target version is the latest Azure Functions Core Tools version that is fetched by func command installed by npm. If you want to test the rollback, you can execute it with `SkipProduction`=true. It is just do the testing. After the rollback, you can execute the health check pipeline that is decribed below. 
+
+### v3 core-tools image health check
+
+This pipeline is trigged every hour. Pull the official images and test the images if it work propery.
+
+* [v3 core-tools image health check (private)](https://azure-functions.visualstudio.com/azure-functions-docker/_build?definitionId=43&_a=summary)
+
+## Trouble Shooting
+
+### Pipeline Fails
+Sometime test fails. In the test, we validated that the latest Azure Functions Core Tools version matches the version of the func command that is inside of the container. Inside of the container, the `func` command is installed by `apt-get` package manager. Sometimes, `npm` package is updated before the `apt-get`. You can refer what happens in the log of Azure Pipeline. 
+In this case, you can ignore it and wait until the apt-get azure functions core tools package is updated. It might take several days, however, since the test is done by `build and test` stage, it won't publish the new images, so no problem. However, keep your eyes on the helthcheck pipeline. 
+
+### Pipeline has got stuck
+Sometimes, I see the issue that Azure Pipelinse stop working during pulling some images. Currently, I don't know the root cause, however, as a workaround, cancel the pipeline and execute it again after waiting for a while. Then  it will success. 
+
+

--- a/host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile
@@ -48,12 +48,13 @@ RUN apt-get update \
     && chown root:root /etc/apt/sources.list.d/microsoft-prod.list \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
     && apt-get update \
-    && apt-get -y install azure-functions-core-tools-3 azure-cli \
+    && apt-get -y install azure-cli azure-functions-core-tools-3 \
     #
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
 
 # Uncomment to opt out of Func CLI telemetry gathering
 #ENV FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=true

--- a/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* 
 
 # Azure Functions Core Tools needs a place to save data
 ENV XDG_DATA_HOME=/home/$USERNAME/.local/share

--- a/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* 
 
 # Azure Functions Core Tools needs a place to save data
 ENV XDG_DATA_HOME=/home/$USERNAME/.local/share

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -1,0 +1,466 @@
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 22 * * *"
+  branches:
+    include:
+    - master
+  always: true
+
+pool:
+  vmImage: ubuntu-18.04
+
+stages:
+- stage: prepare
+  condition: eq(variables['PublishPrivateVersion'], '')
+  jobs:
+  - job: fetchlatest
+    displayName: Check CoreTools Version
+    steps:
+      - bash: |
+          sudo npm i -g azure-functions-core-tools@3 --unsafe-perm true
+          func --version > $(Build.ArtifactStagingDirectory)/core-tools-version.txt
+          date '+%w' > $(Build.ArtifactStagingDirectory)/week.txt
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'drop'
+          publishLocation: 'Container'
+- stage: build
+  condition: eq(variables['PublishPrivateVersion'], '')
+  jobs:
+  - job: dotnetcore3
+    displayName: DotNet Core 3
+    steps: 
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          itemPattern: 
+          downloadPath: '$(System.ArtifactsDirectory)'
+      - bash: |
+          targetVersion=`cat $(System.ArtifactsDirectory)/drop/core-tools-version.txt`
+          privateVersion=${targetVersion}.`cat $(System.ArtifactsDirectory)/drop/week.txt`
+          echo "targetVersion: ${targetVersion}"
+          echo "##vso[task.setvariable variable=TargetVersion;]${targetVersion}"
+          echo "privateVersion: ${privateVersion}"
+          echo "##vso[task.setvariable variable=PrivateVersion;]${privateVersion}"
+        displayName: share the targetVersion and PrivateVersion
+      - bash: |
+          # login
+          set -e
+          echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+        displayName: login to registry
+        continueOnError: false
+        env:
+          pswd: $(dockerPassword)
+
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/dotnet:$(PrivateVersion)-dotnet3-core-tools
+    
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/dotnet/
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: dotnet-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1
+
+  - job: java
+    displayName: Java
+    steps: 
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          itemPattern: 
+          downloadPath: '$(System.ArtifactsDirectory)'
+      - bash: |
+          targetVersion=`cat $(System.ArtifactsDirectory)/drop/core-tools-version.txt`
+          privateVersion=${targetVersion}.`cat $(System.ArtifactsDirectory)/drop/week.txt`
+          echo "targetVersion: ${targetVersion}"
+          echo "##vso[task.setvariable variable=TargetVersion;]${targetVersion}"
+          echo "privateVersion: ${privateVersion}"
+          echo "##vso[task.setvariable variable=PrivateVersion;]${privateVersion}"
+        displayName: share the targetVersion and PrivateVersion
+      - bash: |
+          # login
+          set -e
+          echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+        displayName: login to registry
+        continueOnError: false
+        env:
+          pswd: $(dockerPassword)
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/java:$(PrivateVersion)-java8-core-tools
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/java/java8
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: java8-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/java:$(PrivateVersion)-java11-core-tools
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/java/java11/java11-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/java/java11
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: java11-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1
+
+  - job: node
+    displayName: Node
+    steps:
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          itemPattern: 
+          downloadPath: '$(System.ArtifactsDirectory)'
+      - bash: |
+          targetVersion=`cat $(System.ArtifactsDirectory)/drop/core-tools-version.txt`
+          privateVersion=${targetVersion}.`cat $(System.ArtifactsDirectory)/drop/week.txt`
+          echo "targetVersion: ${targetVersion}"
+          echo "##vso[task.setvariable variable=TargetVersion;]${targetVersion}"
+          echo "privateVersion: ${privateVersion}"
+          echo "##vso[task.setvariable variable=PrivateVersion;]${privateVersion}"
+        displayName: share the targetVersion and PrivateVersion
+      - bash: |
+          # login
+          set -e
+          echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+        displayName: login to registry
+        continueOnError: false
+        env:
+          pswd: $(dockerPassword)
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(PrivateVersion)-node10-core-tools
+
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/node/node10/
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: node10-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/node:$(PrivateVersion)-node12-core-tools
+
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/node/node12/
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: node12-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1
+
+  - job: python
+    displayName: python
+    steps:
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          itemPattern: 
+          downloadPath: '$(System.ArtifactsDirectory)'
+      - bash: |
+          targetVersion=`cat $(System.ArtifactsDirectory)/drop/core-tools-version.txt`
+          privateVersion=${targetVersion}.`cat $(System.ArtifactsDirectory)/drop/week.txt`
+          echo "targetVersion: ${targetVersion}"
+          echo "##vso[task.setvariable variable=TargetVersion;]${targetVersion}"
+          echo "privateVersion: ${privateVersion}"
+          echo "##vso[task.setvariable variable=PrivateVersion;]${privateVersion}"
+        displayName: share the targetVersion and PrivateVersion
+      - bash: |
+          # login
+          set -e
+          echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+        displayName: login to registry
+        continueOnError: false
+        env:
+          pswd: $(dockerPassword)           
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/python:$(PrivateVersion)-python3.8-core-tools
+
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/python/python38/
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: python3.8-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1      
+- stage: publish
+  condition: ne(variables['BuildOnly'], 'true')
+  jobs:
+  - job: testandpublish
+    displayName: Test and Publish Images
+    steps:
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          itemPattern: 
+          downloadPath: '$(System.ArtifactsDirectory)'
+        condition: eq(variables['PublishPrivateVersion'], '')
+      - bash: |
+          targetVersion=""
+          privateVersion=""
+          if [[ ! -z "${publishPrivateVersion}" ]]; then
+            targetVersion="${publishTargetVersion}"
+            privateVersion="${publishPrivateVersion}"
+          else
+            targetVersion=`cat $(System.ArtifactsDirectory)/drop/core-tools-version.txt`
+            privateVersion=${targetVersion}.`cat $(System.ArtifactsDirectory)/drop/week.txt`
+          fi
+          echo "targetVersion: ${targetVersion}"
+          echo "##vso[task.setvariable variable=TargetVersion;]${targetVersion}"
+          echo "privateVersion: ${privateVersion}"
+          echo "##vso[task.setvariable variable=PrivateVersion;]${privateVersion}"
+        displayName: share the targetVersion and PrivateVersion
+        env:
+          publishPrivateVersion: $(PublishPrivateVersion)
+          publishTargetVersion: $(PublishTargetVersion)
+      - bash: |
+          echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+        displayName: login
+        continueOnError: false
+        env:
+          pswd: $(dockerPassword)
+    
+      - bash: |
+          set -e
+          SOURCE_REGISTRY=azurefunctions.azurecr.io/azure-functions/3.0
+          TARGET_REGISTRY=azurefunctions.azurecr.io/public/azure-functions
+
+          MAJOR_VERSION=3.0
+    
+          if [ -z "$(TargetVersion)" ]; then
+            echo "ERROR: TargetVersion is required"
+            exit 1
+          fi
+    
+          echo "##vso[task.setvariable variable=MajorVersion]$MAJOR_VERSION"    
+          echo "##vso[task.setvariable variable=SOURCE_REGISTRY]$SOURCE_REGISTRY"
+          echo "##vso[task.setvariable variable=TARGET_REGISTRY]$TARGET_REGISTRY"
+        displayName: set env
+        continueOnError: false
+    
+      - bash: |
+          set -e
+          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools
+
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
+          
+        displayName: tag dotnet images
+        continueOnError: false
+      - bash: |
+          set -e 
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          ActualVersion=`docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1; 
+          fi
+          docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools az --version
+        displayName: test dotnet images
+        continueOnError: false
+      - bash: |
+          set -e 
+          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
+          docker push $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools
+          docker system prune -a -f
+        displayName: push dotnet images
+        continueOnError: false
+        condition: ne(variables['SkipProduction'], 'true')
+        
+      - bash: |
+          set -e
+          docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools
+          docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-core-tools
+    
+          docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools $TARGET_REGISTRY/java:$(TargetVersion)-java8-core-tools
+          docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-core-tools $TARGET_REGISTRY/java:$(TargetVersion)-java11-core-tools
+  
+          docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools $TARGET_REGISTRY/java:$(MajorVersion)-java8-core-tools
+          docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-core-tools $TARGET_REGISTRY/java:$(MajorVersion)-java11-core-tools  
+    
+        displayName: tag java images
+        continueOnError: false
+      - bash: |
+          set -e 
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/java:$(MajorVersion)-java8-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/java:$(MajorVersion)-java11-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1; 
+          fi
+
+          ActualVersion=`docker run $TARGET_REGISTRY/java:$(MajorVersion)-java8-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi
+          docker run $TARGET_REGISTRY/java:$(MajorVersion)-java8-core-tools az --version
+          ActualVersion=`docker run $TARGET_REGISTRY/java:$(MajorVersion)-java11-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi
+          docker run $TARGET_REGISTRY/java:$(MajorVersion)-java11-core-tools az --version
+        displayName: test java images
+        continueOnError: false
+      - bash: |
+          set -e
+          docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-core-tools
+          docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-core-tools
+
+          docker push $TARGET_REGISTRY/java:$(MajorVersion)-java8-core-tools
+          docker push $TARGET_REGISTRY/java:$(MajorVersion)-java11-core-tools
+    
+          docker system prune -a -f
+        displayName: push java images
+        continueOnError: false
+        condition: ne(variables['SkipProduction'], 'true')
+
+      - bash: |
+          set -e
+          docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools
+          docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools
+    
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-core-tools   
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
+             
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-core-tools   
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools
+
+        displayName: tag node images
+        continueOnError: false
+      - bash: |
+          set -e 
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/node:$(MajorVersion)-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          ActualVersion=`docker run $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi
+          docker run $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools az --version
+          ActualVersion=`docker run $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi          
+          docker run $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools az --version
+        displayName: test node images
+        continueOnError: false        
+      - bash: |
+          set -e
+          docker push $TARGET_REGISTRY/node:$(TargetVersion)-core-tools
+          docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
+          docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
+
+          docker push $TARGET_REGISTRY/node:$(MajorVersion)-core-tools
+          docker push $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools
+          docker push $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools
+    
+          docker system prune -a -f
+        displayName: push node images
+        continueOnError: false
+        condition: ne(variables['SkipProduction'], 'true')
+      - bash: |
+          set -e
+          docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools
+    
+          docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-core-tools
+ 
+          docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools $TARGET_REGISTRY/python:$(MajorVersion)-python3.8-core-tools
+
+        displayName: tag python images
+        continueOnError: false
+
+      - bash: |
+          set -e 
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/python:$(MajorVersion)-python3.8-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          ActualVersion=`docker run $TARGET_REGISTRY/python:$(MajorVersion)-python3.8-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi
+          docker run $TARGET_REGISTRY/python:$(MajorVersion)-python3.8-core-tools az --version
+        displayName: test python images
+        continueOnError: false
+
+      - bash: |
+          set -e
+          docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-core-tools
+          docker push $TARGET_REGISTRY/python:$(MajorVersion)-python3.8-core-tools
+
+          docker system prune -a -f
+        displayName: push python images
+        continueOnError: false
+        condition: ne(variables['SkipProduction'], 'true')

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 22 * * *"
+- cron: "30 22 * * *"
   branches:
     include:
     - master

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -219,7 +219,7 @@ stages:
         env:
           DOCKER_BUILDKIT: 1      
 - stage: publish
-  condition: ne(variables['BuildOnly'], 'true')
+  condition: and(succeeded(), ne(variables['BuildOnly'], 'true'))
   jobs:
   - job: testandpublish
     displayName: Test and Publish Images

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -219,7 +219,7 @@ stages:
         env:
           DOCKER_BUILDKIT: 1      
 - stage: publish
-  condition: and(succeeded(), ne(variables['BuildOnly'], 'true'))
+  condition: and(not(failed('build')), ne(variables['BuildOnly'], 'true'))
   jobs:
   - job: testandpublish
     displayName: Test and Publish Images

--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -69,18 +69,6 @@ steps:
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/dotnet:$(Build.SourceBranchName)-core-tools
-
-      docker build -t $IMAGE_NAME \
-                  -f host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile \
-                  host/3.0/buster/amd64/dotnet/
-      npm run test $IMAGE_NAME --prefix  test/
-      docker push $IMAGE_NAME
-    displayName: dotnet-core-tools
-    continueOnError: false
-
-  - bash: |
-      set -e
       docker run --rm --privileged multiarch/qemu-user-static:register --reset
     displayName: register qemu
     continueOnError: false


### PR DESCRIPTION
This pipeline is Nightly Build Pipeline for publishing Azure Functions Core Tools.  Include documentation for this pipeline. 

![image](https://user-images.githubusercontent.com/1390976/82638302-79085400-9bbb-11ea-9b7d-d38d93d8aac8.png)

The pipeline has multi stage. 

## 1.  prepare
Fetch the latest version of Azure Functions Core Tools. The version will be
`TargetVersion`. (e.g. 3.0.2534)  Also this stage fetch the weekday (0-6). 
## 2. build 
Build and Test images then publish images with `PrivateVersion`.  The `PrivateVersion` will be `TargetVersion` + weekday(0-6). (e.g. 3.0.2534.3)
## 3. publish 
Pull images from Private Docker Registry with `PrivateVersion` then publish with `TargetVersion` and `MajorVersion` (e.g. 3.0) 

## Mode
Pipeline has several mode for testing Dockerfile, Pipeline, and Rollback the images in case of the images are broken. For more details, please refer the documentation. 

## How To Use and Trouble Shooting 
The document covers both scenario. 

## TODO 
PowerShell is not included. 