### PR TITLE
Adding new CODEOWNERS file

### DIFF
--- a/CODEOWNER
+++ b/CODEOWNER
@@ -1,0 +1,12 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+#
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+#
+
+#
+# AZURE FUNCTIONS TEAM
+# For all file changes, github would automatically include the following people in the PRs.
+#
+* @anirudhgarg @Hazhzeng @vrdmr @divyagandhii @balag0 @ankitkumarr @ahmelsayed


### PR DESCRIPTION
Adding a new CODEOWNERS file to automatically add code owners as reviewers to any new PRs.