### PR TITLE
Add Azure files mount support in Kudulite

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -1,3 +1,8 @@
+FROM golang:1.13.1 as go-build-env
+COPY /mesh /mesh
+RUN cd /mesh && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o init
+
 FROM mcr.microsoft.com/oryx/build:20200310.1 as main
 ARG BRANCH
 ARG NAMESPACE
@@ -25,7 +30,11 @@ RUN mkdir -p /opt/Kudu/local \
   && chmod -R 777 /home \
   && rm -rf /tmp/*
 
+COPY --from=go-build-env [ "/mesh/init", "/root/mesh/init" ]
+
 ENV DOTNET_RUNNING_IN_CONTAINER=true
+
+ENV MESH_INIT_URI=http://localhost:6060/
 
 # Enable correct mode for dotnet watch (only mode supported in a container)
 ENV DOTNET_USE_POLLING_FILE_WATCHER=true

--- a/kudulite/mesh/go.mod
+++ b/kudulite/mesh/go.mod
@@ -1,0 +1,3 @@
+module init-server
+
+go 1.12

--- a/kudulite/mesh/main.go
+++ b/kudulite/mesh/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"init-server/pkg/logger"
+	"init-server/pkg/mount"
+	"net/http"
+)
+
+// These are internal operations available for kudulite.
+type internalFunc func(req *http.Request) (string, string, error)
+
+var internalFunctions = map[string]internalFunc{
+	"cifs": mount.RunCifs,
+}
+
+// init server listens on 6060 and accepts request for mounting CIFS file systems
+func startInitServer() {
+	logger.Log("Starting functions handler")
+
+	mux := http.NewServeMux()
+	server := http.Server{Addr: "localhost:6060", Handler: mux}
+
+	mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+		req.ParseForm()
+		operation := req.FormValue("operation")
+
+		logger.Log(fmt.Sprintf("Starting operation: %s\n", operation))
+
+		var err error
+		var stdout, stderr string
+
+		if f, operationFound := internalFunctions[operation]; operationFound {
+			stdout, stderr, err = f(req)
+		} else {
+			err = fmt.Errorf("operation type is invalid")
+		}
+
+		if err != nil {
+			res.WriteHeader(400)
+			fmt.Fprintf(res, "err: %s\nerror: %s\noutput: %s", err.Error(), stderr, stdout)
+		} else {
+			res.WriteHeader(200)
+			fmt.Fprint(res, "OK")
+		}
+	})
+
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Error(err.Error())
+	}
+}
+
+func main() {
+	fmt.Println("Starting init server...")
+	startInitServer()
+}

--- a/kudulite/mesh/pkg/logger/logger.go
+++ b/kudulite/mesh/pkg/logger/logger.go
@@ -1,0 +1,85 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	containerName  = ""
+	stampName      = ""
+	tenantID       = ""
+	kuduLogsFormat = "MS_KUDU_LOGS %d,%s,%s,%s,%s,%d,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%s,%s,%s\n"
+)
+
+func init() {
+	containerName = os.Getenv("CONTAINER_NAME")
+	stampName = os.Getenv("WEBSITE_HOME_STAMPNAME")
+	tenantID = os.Getenv("WEBSITE_STAMP_DEPLOYMENT_ID")
+}
+
+func getSiteName() string {
+
+	const placeholderAppName string = "mesh-placeholder"
+	specializedAppName := os.Getenv("WEBSITE_SITE_NAME")
+
+	if len(specializedAppName) > 0 {
+		return strings.ToLower(specializedAppName)
+	}
+
+	return placeholderAppName
+}
+
+// Error logs errors
+func Error(msg string) {
+	logKudu(msg, 2)
+}
+
+// Warning logs warnings
+func Warning(msg string) {
+	logKudu(msg, 3)
+}
+
+// Log - logs
+func Log(msg string) {
+	logKudu(msg, 4)
+}
+
+func logKudu(msg string, level int) {
+	var (
+		summary         = fmt.Sprintf("\"%s\"", strings.Replace(msg, "\n", " ", -1))
+		errorString     = fmt.Sprintf("\"%s\"", strings.Replace("", "\n", " ", -1))
+		exceptionString = fmt.Sprintf("\"%s\"", strings.Replace("", "\n", " ", -1))
+	)
+
+	fmt.Printf(kuduLogsFormat,
+		level,
+		getSiteName(),
+		"", // project type
+		"", //result
+		errorString,
+		0,  // deployment duration Ms
+		"", //sitemode
+		"", //scm type
+		"", //vs project id
+		"", // jobname
+		"", //script extensio
+		"", //jobType
+		"", //trigger
+		"", //method
+		"", //path
+		summary,
+		exceptionString,
+		"", //route
+		"", //user agent
+		"", //requestId
+		"", //buildversion
+		"", //address
+		"", //verb
+		0,  // statuscode
+		0,  // latencyInMs
+		stampName,
+		tenantID,
+		containerName)
+}

--- a/kudulite/mesh/pkg/mount/mount.go
+++ b/kudulite/mesh/pkg/mount/mount.go
@@ -1,0 +1,118 @@
+package mount
+
+import (
+	"bytes"
+	"fmt"
+	"init-server/pkg/logger"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func run(cmd *exec.Cmd) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	fmt.Println(stdout.String())
+	fmt.Println(stderr.String())
+
+	return stdout.String(), stderr.String(), err
+}
+
+func getIp(host string) (string, error) {
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return "", err
+	}
+
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("Can't find ipv4 for host %s", host)
+}
+
+func callMountCifs(host, accountName, accountKey, contentShare, targetPath string) (string, string, error) {
+
+	logger.Log("Init callMountCifs")
+
+	cmd := exec.Command("mount",
+		"-t",
+		"cifs",
+		fmt.Sprintf("//%s/%s", host, contentShare),
+		targetPath,
+		"-o",
+		fmt.Sprintf("vers=3.0,username=%s,password=%s,dir_mode=0777,file_mode=0777,serverino", accountName, accountKey))
+	return run(cmd)
+}
+
+func callMountSyscall(host, accountName, accountKey, contentShare, targetPath string) error {
+	logger.Log("Init callMountSyscall")
+
+	ip, err := getIp(host)
+	if err != nil {
+		logger.Log("Failed to get Ip Address in callMountSyscall")
+		return err
+	}
+
+	logger.Log(fmt.Sprintf("Storage host ip =: %s\n", ip))
+
+	err = syscall.Mount(fmt.Sprintf("//%s/%s", host, contentShare),
+		targetPath,
+		"cifs",
+		0,
+		fmt.Sprintf("ip=%s,unc=\\\\%s\\%s,vers=3.0,username=%s,password=%s,dir_mode=0777,file_mode=0777,serverino", ip, host, contentShare, accountName, accountKey))
+
+	if err != nil {
+		logger.Log(fmt.Sprintf("syscall.Mount failed: %s", err.Error()))
+		fmt.Println("%v", err)
+	}
+
+	return err
+}
+
+// RunCifs runs mount -t cifs to mount a cifs file share
+func RunCifs(req *http.Request) (string, string, error) {
+	logger.Log("Init RunCifs")
+
+	return runCifsInternal(req.FormValue("host"),
+		req.FormValue("accountName"),
+		req.FormValue("accountKey"),
+		req.FormValue("contentShare"),
+		req.FormValue("targetPath"))
+}
+
+func runCifsInternal(host, accountName, accountKey, contentShare, targetPath string) (string, string, error) {
+	logger.Log("Init runCifsInternal")
+
+	if host == "" || accountName == "" || accountKey == "" || contentShare == "" || targetPath == "" {
+		return "", "", fmt.Errorf("host, accountName, accountKey, contentShare and targetPath are required")
+	}
+
+	logger.Log("Creating directory..")
+
+	// make sure targetPath exists
+	err := os.MkdirAll(targetPath, os.ModePerm)
+	if err != nil {
+		logger.Log("Creating directory failed")
+		return "", "", err
+	}
+
+	logger.Log("Created directory successfully")
+
+	err = callMountSyscall(host, accountName, accountKey, contentShare, targetPath)
+
+	if err != nil {
+		logger.Log(fmt.Sprintf("Mount by syscall failed. Attempting to mount using mount cmd"))
+		return callMountCifs(host, accountName, accountKey, contentShare, targetPath)
+	} else {
+		logger.Log(fmt.Sprintf("Mount by syscall succeeded."))
+	}
+
+	return "", "", nil
+}

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -28,6 +28,8 @@ if [ -z "${PORT}" ]; then
     export PORT=80
 fi
 
+/root/mesh/init &
+
 GROUP_ID=$1
 GROUP_NAME=$2
 USER_ID=$3


### PR DESCRIPTION
Adds support to mount Azure file shares in Kudulite. This will provide persistent storage in linux consumption scm sites.

https://github.com/Azure-App-Service/KuduLite/pull/121
uses this feature to store deployment logs.

