### PR TITLE
Upgrade java versions

### DIFF
--- a/host/3.0/buster/amd64/java/java11/java11-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-appservice.Dockerfile
@@ -29,8 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
-# mcr.microsoft.com/java/jre doesn't have a debian 10 image yet.
-FROM mcr.microsoft.com/java/jre:11u3-zulu-debian9 as jre
+FROM mcr.microsoft.com/java/jre-headless:11u6-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
@@ -44,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
-COPY --from=jre [ "/usr/lib/jvm/zre-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]
+COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -29,8 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
-# mcr.microsoft.com/java/jre doesn't have a debian 10 image yet.
-FROM mcr.microsoft.com/java/jre:11u3-zulu-debian9 as jre
+FROM mcr.microsoft.com/java/jre-headless:11u6-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
@@ -42,7 +41,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
-COPY --from=jre [ "/usr/lib/jvm/zre-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]
+COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]
 
 ENV JAVA_HOME /usr/lib/jvm/zre-11-azure-amd64
 

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
-FROM mcr.microsoft.com/java/jre:11u3-zulu-debian9 as jre
+FROM mcr.microsoft.com/java/jre-headless:11u6-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
@@ -41,7 +41,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
-COPY --from=jre [ "/usr/lib/jvm/zre-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]
+COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]
 
 ENV JAVA_HOME /usr/lib/jvm/zre-11-azure-amd64
 

--- a/host/3.0/buster/amd64/java/java8/java8-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-appservice.Dockerfile
@@ -28,8 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
-# mcr.microsoft.com/java/jdk doesn't have a debian 10 image yet.
-FROM mcr.microsoft.com/java/jre:8u212-zulu-debian9 as jre
+FROM mcr.microsoft.com/java/jre-headless:8u242-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
@@ -43,7 +42,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
-COPY --from=jre [ "/usr/lib/jvm/zre-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]
+COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -28,8 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
-# mcr.microsoft.com/java/jdk doesn't have a debian 10 image yet.
-FROM mcr.microsoft.com/java/jre:8u212-zulu-debian9 as jre
+FROM mcr.microsoft.com/java/jre-headless:8u242-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
@@ -41,7 +40,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
-COPY --from=jre [ "/usr/lib/jvm/zre-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]
+COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]
 
 ENV JAVA_HOME /usr/lib/jvm/zre-8-azure-amd64
 

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
-FROM mcr.microsoft.com/java/jre:8u212-zulu-debian9 as jre
+FROM mcr.microsoft.com/java/jre-headless:8u242-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
@@ -40,7 +40,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
-COPY --from=jre [ "/usr/lib/jvm/zre-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]
+COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]
 
 ENV JAVA_HOME /usr/lib/jvm/zre-8-azure-amd64
 


### PR DESCRIPTION
- We are upgrading the java run time to be aligned with Ant89.
- We are using debian10 images.
- We are using with tools that will support jstack and jcmd tooling.