### PR TITLE
Fix: CVE-2020-1108: .NET Core Denial of Service Vulnerability

### DIFF
--- a/host/3.0/buster/amd64/powershell/powershell6-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-core-tools.Dockerfile
@@ -11,7 +11,7 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-ARG PS_VERSION=6.2.5
+ARG PS_VERSION=6.2.7
 ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.9_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
https://github.com/PowerShell/Announcements/issues/20

@AnatoliB @Francisco-Gamino 

We update the PowerShell for fixing CVE-2020-1108 . 

Fixed version. 

7.0 | 7.0.2
-- | --
6.2 | 6.2.6

