### PR TITLE
Bumped PowerShell version to 7.0.3

### DIFF
--- a/host/3.0/buster/amd64/powershell/powershell7-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7-core-tools.Dockerfile
@@ -11,7 +11,7 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-ARG PS_VERSION=7.0.1
+ARG PS_VERSION=7.0.3
 ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.10_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
Bumped PowerShell version to 7.0.3 as this is now the latest stable release.

There is no PowerShell 7 version in the build YAML in the repo for the 3.0 hosts. I can have a go at adding this based on the PowerShell 6 examples.

