### PR TITLE
Use runtime-deps:2.1 for V2 images to get latest os updates 

### DIFF
--- a/host/2.0/stretch/amd64/dotnet/dotnet-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet-appservice.Dockerfile
@@ -30,7 +30,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 # dotnet-appservice image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/2.0/stretch/amd64/dotnet/dotnet-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet-slim.Dockerfile
@@ -30,7 +30,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 # dotnet-slim image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/2.0/stretch/amd64/dotnet/dotnet.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet.Dockerfile
@@ -30,7 +30,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 # dotnet image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/2.0/stretch/amd64/java/java8-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8-appservice.Dockerfile
@@ -36,7 +36,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
 
 # java8-appservice image
 FROM mcr.microsoft.com/java/jre:8u212-zulu-debian9 as jre
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 EXPOSE 2222 80

--- a/host/2.0/stretch/amd64/java/java8-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8-slim.Dockerfile
@@ -31,7 +31,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
 
 # java8-slim image
 FROM openjdk:8-jdk as jdk
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/2.0/stretch/amd64/java/java8.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8.Dockerfile
@@ -31,7 +31,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
 
 # java8 image
 FROM openjdk:8-jdk as jdk
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/2.0/stretch/amd64/node/node10/node10-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10-appservice.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
 # node10-appservice image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10-slim.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
 # node10-slim image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node10/node10.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
 # node10 image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node12/node12-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12-appservice.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
 # node10-appservice image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12-slim.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
 # node12-slim image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node12/node12.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12.Dockerfile
@@ -29,7 +29,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2
 
 # node12 image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node8/node8-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8-appservice.Dockerfile
@@ -30,7 +30,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 # node8-appservice image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node8/node8-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8-slim.Dockerfile
@@ -30,7 +30,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 # node8-slim image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/2.0/stretch/amd64/node/node8/node8.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8.Dockerfile
@@ -30,7 +30,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.3.2 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 # node8 image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1
 ARG HOST_VERSION
 
 RUN apt-get update && \


### PR DESCRIPTION
updated runtime-deps:2.2 image is no longer available.