### PR TITLE
Use runtime-deps:2.1-bionic-arm32v7 as the base image for 2.2 bionic arm32 image

### DIFF
--- a/host/2.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/2.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -34,8 +34,26 @@ RUN apt-get update && \
     apt-get install -y qemu-user qemu-user-static
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic-arm32v7
+# Simulate mcr.microsoft.com/dotnet/core/aspnet:2.2-bionic-arm32v7 based on https://github.com/dotnet/dotnet-docker/blob/master/src/aspnet/2.1/bionic/arm32v7/Dockerfile
+# Workaround to get the patched 2.1 deps and asp.net v2.2
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.1-bionic-arm32v7
 ARG HOST_VERSION
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ASP.NET Core
+ENV ASPNETCORE_VERSION 2.2.8
+
+RUN curl -SL --output aspnetcore.tar.gz https://dotnetcli.azureedge.net/dotnet/aspnetcore/Runtime/$ASPNETCORE_VERSION/aspnetcore-runtime-$ASPNETCORE_VERSION-linux-arm.tar.gz \
+    && aspnetcore_sha512='fab9a1d9d101716337bb153af2ac36429fc387230c0c0bf2d639b31fb7f787bc8dbaaa31f28f9cbe69f117ffc78d8ddb5a5968da0e77785d3c12c6814ef50f7b' \
+    && echo "$aspnetcore_sha512  aspnetcore.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf aspnetcore.tar.gz -C /usr/share/dotnet \
+    && rm aspnetcore.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 COPY --from=runtime-image ["/usr/bin/qemu-arm-static", "/usr/bin"]
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]


### PR DESCRIPTION
Patched mcr.microsoft.com/dotnet/core/runtime-deps:2.2-bionic-arm32v7 is no longer available.

Using the latest 2.2 version from https://dotnet.microsoft.com/download/dotnet-core/2.2
SHA512 checksum from https://dotnetcli.blob.core.windows.net/dotnet/checksums/2.2.8-sha.txt