### PR TITLE
Reduce KuduLite image size

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -3,7 +3,7 @@ COPY /mesh /mesh
 RUN cd /mesh && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o init
 
-FROM mcr.microsoft.com/oryx/build:20200310.1 as main
+FROM mcr.microsoft.com/oryx/build:20200813.1 as main
 ARG BRANCH
 ARG NAMESPACE
 ENV DEBIAN_FRONTEND noninteractive
@@ -12,20 +12,18 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
   && apt-get install -y vim tree --no-install-recommends \
   && apt-get install -y tcptraceroute \
-# Install Squashfs tools for KuduLite build
+  # SQL Server gem support
+  && apt-get install -y unixodbc-dev freetds-dev freetds-bin \
+  # Install Squashfs tools for KuduLite build
   && apt-get install -y squashfs-tools \
+  # Install Kudu dependencies
+  && apt-get install -y unzip \
   && wget -O /usr/bin/tcpping http://www.vdberg.org/~richard/tcpping \
   && chmod 755 /usr/bin/tcpping
-
-# SQL Server gem support
-RUN apt-get install -y unixodbc-dev freetds-dev freetds-bin
 
 # Install Kudu
 RUN mkdir -p /opt/Kudu/local \
   && chmod 755 /opt/Kudu/local \
-  && apt-get update \
-  && apt-get  install -y unzip \
-# Install pm2 and pm2-logrotate
   && mkdir -p /home/LogFiles \
   && chmod -R 777 /home \
   && rm -rf /tmp/*
@@ -45,13 +43,11 @@ ENV NUGET_XMLDOC_MODE=skip
 RUN dotnet tool install -g dotnet-aspnet-codegenerator --version 2.2.4
 ENV PATH=$PATH:/root/.dotnet/tools
 
-#Instal Kudu
+# Install Kudu
 RUN cd /tmp \
-    && git clone https://github.com/$NAMESPACE/KuduLite.git \
-    && cd ./KuduLite \
-    && git checkout $BRANCH \
-    && cd ./Kudu.Services.Web \
-    && benv dotnet=2.2 dotnet publish -c Release -o /opt/Kudu \
+    && git clone --depth 1 --branch $BRANCH https://github.com/$NAMESPACE/KuduLite.git KuduLite \
+    && cd ./KuduLite/Kudu.Services.Web \
+    && benv dotnet=3.1 dotnet publish -c Release -o /opt/Kudu \
     && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \
     && rm -rf /tmp/* \
     && chmod a+rw /var/nuget \
@@ -61,11 +57,20 @@ COPY startup.sh /
 
 RUN chmod 777 /startup.sh
 
-RUN benv node=9 npm=6 npm install -g kudusync
-RUN benv node=9 npm=6 npm install pm2@latest -g
+RUN benv node=9 npm=6 npm install -g kudusync pm2@latest
 
 RUN ln -s /opt/nodejs/9/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm-cli.js
 ENV PATH=$PATH:/opt/nodejs/9/bin
+
+# Use Dynamic Install SDK feature from Oryx build
+# Trim off all unnecessary SDKs and let them lazily loaded
+RUN rm -rf /opt/python /opt/hugo /opt/php /opt/php-composer \
+    # We still need the fundamental ones when building the images nodejs 9, npm 6 and dotnet 3.1
+    && find /opt/nodejs -mindepth 1 -maxdepth 1 -type d,l -not -name "9*" | xargs rm -rf \
+    && find /opt/npm -mindepth 1 -maxdepth 1 -type d,l -not -name "6*" | xargs rm -rf \
+    && find /opt/dotnet/runtimes -mindepth 1 -maxdepth 1 -type d,l -not -name '3*' | xargs rm -rf \
+    && find /opt/dotnet/sdks -mindepth 1 -maxdepth 1 -type d,l -not -name '3*' | xargs rm -rf
+ENV ENABLE_DYNAMIC_INSTALL=true
 
 EXPOSE 80
 

--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH=$PATH:/root/.dotnet/tools
 RUN cd /tmp \
     && git clone --depth 1 --branch $BRANCH https://github.com/$NAMESPACE/KuduLite.git KuduLite \
     && cd ./KuduLite/Kudu.Services.Web \
-    && benv dotnet=3.1 dotnet publish -c Release -o /opt/Kudu \
+    && benv dotnet=2.2 dotnet publish -c Release -o /opt/Kudu \
     && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \
     && rm -rf /tmp/* \
     && chmod a+rw /var/nuget \

--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -3,7 +3,7 @@ COPY /mesh /mesh
 RUN cd /mesh && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o init
 
-FROM mcr.microsoft.com/oryx/build:20200813.1 as main
+FROM mcr.microsoft.com/oryx/build:20200813.1 as pre-final-env
 ARG BRANCH
 ARG NAMESPACE
 ENV DEBIAN_FRONTEND noninteractive
@@ -74,5 +74,35 @@ ENV ENABLE_DYNAMIC_INSTALL=true
 
 EXPOSE 80
 
+# Squash all layers into a few
+FROM scratch
+
+COPY --from=pre-final-env / /
+
+ENV AZURE_FUNCTIONS_ENVIRONMENT=production \
+    DEBIAN_FRONTEND=noninteractive \
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    ENABLE_DYNAMIC_INSTALL=true \
+    HOME=/home \
+    LANG=C.UTF-8 \
+    MESH_INIT_URI=http://localhost:6060/ \
+    NUGET_PACKAGES=/var/nuget \
+    NUGET_XMLDOC_MODE=skip \
+    ORIGINAL_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    ORYX_AI_INSTRUMENTATION_KEY=4aadba6b-30c8-42db-9b93-024d5c62b887 \
+    ORYX_PATHS=/opt/oryx:/opt/nodejs/lts/bin:/opt/dotnet/sdks/lts:/opt/python/latest/bin:/opt/php/lts/bin:/opt/php-composer:/opt/yarn/stable/bin:/opt/hugo/lts \
+    ORYX_SDK_STORAGE_BASE_URL=https://oryx-cdn.microsoft.io \
+    PATH=/opt/oryx:/opt/nodejs/lts/bin:/opt/dotnet/sdks/lts:/opt/python/latest/bin:/opt/php/lts/bin:/opt/php-composer:/opt/yarn/stable/bin:/opt/hugo/lts:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.dotnet/tools:/opt/nodejs/9/bin \
+    PYTHONIOENCODING=UTF-8 \
+    SHLVL=1 \
+    TERM=xterm \
+    WEBSITE_MOUNT_ENABLED=1 \
+    WEBSITE_PLACEHOLDER_MODE=1
+
+WORKDIR /
+
 ENTRYPOINT [ "/startup.sh" ]
+
 CMD [ "1002", "kudu_group", "1001", "root", "localsite" ]

--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -65,11 +65,12 @@ ENV PATH=$PATH:/opt/nodejs/9/bin
 # Use Dynamic Install SDK feature from Oryx build
 # Trim off all unnecessary SDKs and let them lazily loaded
 RUN rm -rf /opt/python /opt/hugo /opt/php /opt/php-composer \
-    # We still need the fundamental ones when building the images nodejs 9, npm 6 and dotnet 3.1
+    # We still need the fundamental ones when building the images nodejs 9, npm 6 and dotnet 2.2
+    # TODO: This will be upgraded to dotnet 3.1 soon
     && find /opt/nodejs -mindepth 1 -maxdepth 1 -type d,l -not -name "9*" | xargs rm -rf \
     && find /opt/npm -mindepth 1 -maxdepth 1 -type d,l -not -name "6*" | xargs rm -rf \
-    && find /opt/dotnet/runtimes -mindepth 1 -maxdepth 1 -type d,l -not -name '3*' | xargs rm -rf \
-    && find /opt/dotnet/sdks -mindepth 1 -maxdepth 1 -type d,l -not -name '3*' | xargs rm -rf
+    && find /opt/dotnet/runtimes -mindepth 1 -maxdepth 1 -type d,l -not -name '2*' | xargs rm -rf \
+    && find /opt/dotnet/sdks -mindepth 1 -maxdepth 1 -type d,l -not -name '2*' | xargs rm -rf
 ENV ENABLE_DYNAMIC_INSTALL=true
 
 EXPOSE 80

--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -32,7 +32,7 @@ base_dir=$DIR
 # Free up CI disk space
 if ! [ -z "$CI_RUN" ]; then
     echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up dangling images to free up CI space... ${CONSOLE_RESET}"
-    docker image prune -f
+    docker system prune -f
 fi
 
 # Build image
@@ -45,5 +45,5 @@ docker build --no-cache --build-arg BRANCH="$branch" --build-arg NAMESPACE="$nam
 # Remove the huge oryx build image
 if ! [ -z "$CI_RUN" ]; then
     echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Deleting dangling oryx build image... ${CONSOLE_RESET}"
-    docker rmi -f $(docker images | grep 'mcr.microsoft.com/oryx/build')
+    docker image prune -f
 fi

--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -29,13 +29,14 @@ fi
 
 base_dir=$DIR
 
+# Free up CI disk space
+if ! [ -z "$CI_RUN" ]; then
+    echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up... ${CONSOLE_RESET}"
+    docker system prune -f -a
+fi
+
 current_image="$ACR/$ACR_NAMESPACE/kudulite:$tag"
 echo -e "${CONSOLE_BOLD}${COLOR_GREEN}: Building $current_image ${CONSOLE_RESET}"
 echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Source Image $namespace/KuduLite $branch ${CONSOLE_RESET}"
 echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Destination Image $current_image ${CONSOLE_RESET}"
 docker build --no-cache --build-arg BRANCH="$branch" --build-arg NAMESPACE="$namespace" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
-
-if ! [ -z "$CI_RUN" ]; then
-    echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up... ${CONSOLE_RESET}"
-    docker system prune -f -a
-fi

--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -31,12 +31,19 @@ base_dir=$DIR
 
 # Free up CI disk space
 if ! [ -z "$CI_RUN" ]; then
-    echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up... ${CONSOLE_RESET}"
-    docker system prune -f -a
+    echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up dangling images to free up CI space... ${CONSOLE_RESET}"
+    docker image prune -f
 fi
 
+# Build image
 current_image="$ACR/$ACR_NAMESPACE/kudulite:$tag"
 echo -e "${CONSOLE_BOLD}${COLOR_GREEN}: Building $current_image ${CONSOLE_RESET}"
 echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Source Image $namespace/KuduLite $branch ${CONSOLE_RESET}"
 echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Destination Image $current_image ${CONSOLE_RESET}"
 docker build --no-cache --build-arg BRANCH="$branch" --build-arg NAMESPACE="$namespace" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
+
+# Remove the huge oryx build image
+if ! [ -z "$CI_RUN" ]; then
+    echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Deleting dangling oryx build image... ${CONSOLE_RESET}"
+    docker rmi -f $(docker images | grep 'mcr.microsoft.com/oryx/build')
+fi

--- a/kudulite/build.vsts-ci.yml
+++ b/kudulite/build.vsts-ci.yml
@@ -24,7 +24,7 @@ steps:
     set -e
     echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
 
-  displayName: login to registry
+  displayName: Login to ACR Registry
   continueOnError: false
   env:
     pswd: $(dockerPassword)
@@ -36,12 +36,31 @@ steps:
     export namespace=$(namespace)
     export branch=$(branch)
     export tag=$(tag)
-    export storageAccountName=$(storageAccountName)
-    export storageAccountKey=$(storageAccountKey)
-    export siteRestrictedToken=$(siteRestrictedToken)
-    export v2RuntimeVersion=$(v2RuntimeVersion)
-    export v3RuntimeVersion=$(v3RuntimeVersion)
     chmod +x ./kudulite/build.sh
     ./kudulite/build.sh
-  displayName: build images
+  displayName: Build KuduLite Image
+  continueOnError: false
+
+- bash: |
+    set -e
+    export CI_RUN=1
+    export RUN_TESTS=1
+    export tag=$(tag)
+    export storageAccountName=$(storageAccountName)
+    export storageAccountKey=$(storageAccountKey)
+    export v2RuntimeVersion=$(v2RuntimeVersion)
+    export v3RuntimeVersion=$(v3RuntimeVersion)
+    chmod +x ./kudulite/test.sh
+    ./kudulite/test.sh
+  displayName: Test KuduLite Image
+  continueOnError: false
+
+- bash: |
+    set -e
+    export CI_RUN=1
+    export RUN_TESTS=1
+    export tag=$(tag)
+    chmod +x ./kudulite/publish.sh
+    ./kudulite/publish.sh
+  displayName: Publish KuduLite Image
   continueOnError: false

--- a/kudulite/publish.sh
+++ b/kudulite/publish.sh
@@ -15,14 +15,6 @@ CONSOLE_BOLD=$ESC_SEQ"1m"
 ACR=azurefunctions.azurecr.io
 ACR_NAMESPACE=public/azure-functions
 
-if [ -z "$namespace" ]; then
-    namespace="Azure-App-Service"
-fi
-
-if [ -z "$branch" ]; then
-    branch=master
-fi
-
 if [ -z "$tag" ]; then
     tag=dev
 fi
@@ -30,10 +22,9 @@ fi
 base_dir=$DIR
 
 current_image="$ACR/$ACR_NAMESPACE/kudulite:$tag"
-echo -e "${CONSOLE_BOLD}${COLOR_GREEN}: Building $current_image ${CONSOLE_RESET}"
-echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Source Image $namespace/KuduLite $branch ${CONSOLE_RESET}"
-echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Destination Image $current_image ${CONSOLE_RESET}"
-docker build --no-cache --build-arg BRANCH="$branch" --build-arg NAMESPACE="$namespace" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
+
+echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Test PASSED. Pushing $current_image ${CONSOLE_RESET}"
+docker push "$current_image"
 
 if ! [ -z "$CI_RUN" ]; then
     echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up... ${CONSOLE_RESET}"

--- a/kudulite/publish.sh
+++ b/kudulite/publish.sh
@@ -28,5 +28,5 @@ docker push "$current_image"
 
 if ! [ -z "$CI_RUN" ]; then
     echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up... ${CONSOLE_RESET}"
-    docker system prune -f -a
+    docker system prune -f
 fi

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -50,4 +50,5 @@ export APPDATA=/opt/Kudu/local
 cd /opt/Kudu
 
 echo $(date) running .net core
-ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=3.1 dotnet Kudu.Services.Web.dll
+# TODO: This will be updated to dotnet 3.1 soon
+ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2 dotnet Kudu.Services.Web.dll

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -50,4 +50,4 @@ export APPDATA=/opt/Kudu/local
 cd /opt/Kudu
 
 echo $(date) running .net core
-ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2 dotnet Kudu.Services.Web.dll
+ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=3.1 dotnet Kudu.Services.Web.dll

--- a/kudulite/test.sh
+++ b/kudulite/test.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+set -e
+
+DIR=$(dirname $0)
+ESC_SEQ="\033["
+CONSOLE_RESET=$ESC_SEQ"39;49;00m"
+COLOR_RED=$ESC_SEQ"31;01m"
+COLOR_GREEN=$ESC_SEQ"32;01m"
+COLOR_YELLOW=$ESC_SEQ"33;01m"
+COLOR_CYAN=$ESC_SEQ"36;01m"
+CONSOLE_BOLD=$ESC_SEQ"1m"
+
+# Building stretch
+ACR=azurefunctions.azurecr.io
+ACR_NAMESPACE=public/azure-functions
+
+if [ -z "$tag" ]; then
+    tag=dev
+fi
+
+base_dir=$DIR
+
+current_image="$ACR/$ACR_NAMESPACE/kudulite:$tag"
+
+echo -e "${CONSOLE_BOLD}${COLOR_YELLOW} Testing $current_image ${CONSOLE_RESET}"
+export STORAGE_ACCOUNT_NAME="$storageAccountName"
+export STORAGE_ACCOUNT_KEY="$storageAccountKey"
+export V2_RUNTIME_VERSION="$v2RuntimeVersion"
+export V3_RUNTIME_VERSION="$v3RuntimeVersion"
+npm run test-kudulite $current_image --prefix test/

--- a/test/kudulite/containers.ts
+++ b/test/kudulite/containers.ts
@@ -264,14 +264,12 @@ export class KuduContainer {
       }
 
       // Clean up docker image
-      /*
       console.log(chalk.yellow(`Cleaning up image ${baseImage}...`));
       const rmiCommand = `docker rmi -f ${baseImage}`;
       const rmiResult = shell.exec(rmiCommand);
       if (rmiResult.code !== 0) {
         console.log(chalk.red.bold(`Failed to remove runtime image ${baseImage}`));
       }
-      */
       delete KuduContainer.ports[destContainerName];
     }
 

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -85,17 +85,16 @@ async function main() {
   const testHost30Node12 = new Host30Node12();
 
   try {
-    await Promise.all([
-      testHost20Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`),
-      testHost20Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-python3.7`),
-      testHost20Node8.run(config, 'KuduLiteNode8.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`),
-      testHost20Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-node10`),
-      testHost30Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`),
-      testHost30Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`),
-      testHost30Python38.run(config, 'KuduLitePython38.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`),
-      testHost30Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`),
-      testHost30Node12.run(config, 'KuduLiteNode12.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-node12`),
-    ]);
+    // CI disk space limitation hit, fail to run all tests parallelly.
+    await testHost20Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
+    await testHost20Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-python3.7`);
+    await testHost20Node8.run(config, 'KuduLiteNode8.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
+    await testHost20Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-node10`);
+    await testHost30Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+    await testHost30Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`);
+    await testHost30Python38.run(config, 'KuduLitePython38.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`);
+    await testHost30Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+    await testHost30Node12.run(config, 'KuduLiteNode12.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-node12`);
   } catch (error) {
     console.log(chalk.red.bold(error));
     process.exit(1)


### PR DESCRIPTION
Previously our KuduLite image reaches 8.78GB and Atlas team has hard time caching our images.

### Fixes
In this PR, I made a few improvements to reduce the image size:
1. Turning on ENABLE_DYNAMIC_INSTALL, this is a Oryx feature to lazy load deployment tools (e.g. pip, npm, dotnet) only when customer triggers a build.
2. Clean up built-in SDKs by removing python, php, hugo and stripping nodejs!=9 and dotnet~2.
3. Squash the final image into a single layer.

### Miscellaneous
1. Update KuduLite website to use .NetCore 3.1

### Validation
Building the image from https://github.com/Hazhzeng/KuduLite/tree/hazeng-stage.
Uploaded the image to docker hub rogerxman/test:kudu-one and tested on private stamp.

The newly generated image now takes 3.01 GB.