### PR TITLE
Add test infrastructure for remote build

### DIFF
--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -34,8 +34,17 @@ echo -e "${CONSOLE_BOLD}${COLOR_GREEN}: Building $current_image ${CONSOLE_RESET}
 echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Source Image $namespace/KuduLite $branch ${CONSOLE_RESET}"
 echo -e "${CONSOLE_BOLD}${COLOR_YELLOW}: Destination Image $current_image ${CONSOLE_RESET}"
 docker build --no-cache --build-arg BRANCH="$branch" --build-arg NAMESPACE="$namespace" -t $current_image -f "$base_dir/Dockerfile" "$base_dir"
+
+echo -e "${CONSOLE_BOLD}${COLOR_YELLOW} Testing $current_image ${CONSOLE_RESET}"
+export STORAGE_ACCOUNT_NAME="$storageAccountName"
+export STORAGE_ACCOUNT_KEY="$storageAccountKey"
+export SITE_RESTRICTED_TOKEN="$siteRestrictedToken"
+npm run test-kudulite $current_image --prefix test/
+
+echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Test PASSED. Pushing $current_image ${CONSOLE_RESET}"
 docker push "$current_image"
 
 if ! [ -z "$CI_RUN" ]; then
+    echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Cleaning up... ${CONSOLE_RESET}"
     docker system prune -f -a
 fi

--- a/kudulite/build.sh
+++ b/kudulite/build.sh
@@ -39,6 +39,8 @@ echo -e "${CONSOLE_BOLD}${COLOR_YELLOW} Testing $current_image ${CONSOLE_RESET}"
 export STORAGE_ACCOUNT_NAME="$storageAccountName"
 export STORAGE_ACCOUNT_KEY="$storageAccountKey"
 export SITE_RESTRICTED_TOKEN="$siteRestrictedToken"
+export V2_RUNTIME_VERSION="$v2RuntimeVersion"
+export V3_RUNTIME_VERSION="$v3RuntimeVersion"
 npm run test-kudulite $current_image --prefix test/
 
 echo -e "${CONSOLE_BOLD}${COLOR_GREEN} Test PASSED. Pushing $current_image ${CONSOLE_RESET}"

--- a/kudulite/build.vsts-ci.yml
+++ b/kudulite/build.vsts-ci.yml
@@ -39,6 +39,8 @@ steps:
     export storageAccountName=$(storageAccountName)
     export storageAccountKey=$(storageAccountKey)
     export siteRestrictedToken=$(siteRestrictedToken)
+    export v2RuntimeVersion=$(v2RuntimeVersion)
+    export v3RuntimeVersion=$(v3RuntimeVersion)
     chmod +x ./kudulite/build.sh
     ./kudulite/build.sh
   displayName: build images

--- a/kudulite/build.vsts-ci.yml
+++ b/kudulite/build.vsts-ci.yml
@@ -7,6 +7,7 @@ pr:
   paths:
     include:
     - kudulite/*
+    - test/kudulite*
 
 trigger:
   branches:
@@ -15,6 +16,7 @@ trigger:
   paths:
     include:
     - kudulite/*
+    - test/kudulite*
 
 steps:
 - bash: |
@@ -34,6 +36,9 @@ steps:
     export namespace=$(namespace)
     export branch=$(branch)
     export tag=$(tag)
+    export storageAccountName=$(storageAccountName)
+    export storageAccountKey=$(storageAccountKey)
+    export siteRestrictedToken=$(siteRestrictedToken)
     chmod +x ./kudulite/build.sh
     ./kudulite/build.sh
   displayName: build images

--- a/test/kudulite/containers.ts
+++ b/test/kudulite/containers.ts
@@ -95,7 +95,7 @@ export class KuduContainer {
   }
 
   public async startKuduLiteContainer(extraEnvVars: Record<string, any> = {}): Promise<string> {
-    return this.startContainer(this.config.testImageName, this.containerName, extraEnvVars);
+    return this.startContainer(this.config.kuduliteImage, this.containerName, extraEnvVars);
   }
 
   public async startRuntimeContainer(image: string, extraEnvVars: Record<string, any> = {}): Promise<string> {
@@ -264,12 +264,14 @@ export class KuduContainer {
       }
 
       // Clean up docker image
+      /*
       console.log(chalk.yellow(`Cleaning up image ${baseImage}...`));
       const rmiCommand = `docker rmi -f ${baseImage}`;
       const rmiResult = shell.exec(rmiCommand);
       if (rmiResult.code !== 0) {
         console.log(chalk.red.bold(`Failed to remove runtime image ${baseImage}`));
       }
+      */
       delete KuduContainer.ports[destContainerName];
     }
 

--- a/test/kudulite/containers.ts
+++ b/test/kudulite/containers.ts
@@ -1,0 +1,270 @@
+import axios from "axios";
+import fs from "fs";
+import chalk from "chalk";
+import path from "path";
+import shell from "shelljs";
+import { BlobServiceClient, ContainerClient, generateBlobSASQueryParameters, BlobSASPermissions, StorageSharedKeyCredential } from "@azure/storage-blob";
+import { timeout, retry } from './utils';
+import { IConfig } from './interfaces';
+
+export class KuduContainer {
+  static envVars: Record<string, string> = {
+    CONTAINER_ENCRYPTION_KEY: 'MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=',
+    WEBSITE_AUTH_ENCRYPTION_KEY: 'E782F47415EEC076F8087729FB30CF1CA1482610C2FA985E4F22531225722205',
+    WEBSITE_SITE_NAME: 'kudulitetest',
+    WEBSITE_HOSTNAME: 'kudulitetest.azurewebsites.net'
+  }
+
+  // Map of containerId -> port mapping
+  static ports: Record<string, number> = {}
+  private createdDate: Date;
+  private containerId: string;
+  private containerName: string;
+  private storageCredential: StorageSharedKeyCredential;
+  private storageClient: BlobServiceClient;
+  private srcContainerClient: ContainerClient;
+  private destContainerClient: ContainerClient;
+  private tempFolderPath: string;
+
+  constructor(private config: IConfig) {
+    this.createdDate = new Date();
+    this.containerId = this.getUniqueContainerId();
+    this.containerName = `kudulite${this.containerId}`;
+    this.storageCredential = new StorageSharedKeyCredential(config.storageAccountName, config.storageAccountKey);
+    this.storageClient = new BlobServiceClient(`https://${config.storageAccountName}.blob.core.windows.net`, this.storageCredential);
+    this.srcContainerClient = this.storageClient.getContainerClient(config.srcContainerName);
+    this.destContainerClient = this.storageClient.getContainerClient(config.destContainerName);
+
+    this.tempFolderPath = path.join('/tmp', 'kudulite_test', this.containerId);
+    fs.mkdirSync(this.tempFolderPath, { recursive: true });
+    console.log(chalk.green(`Created temporary folder ${this.tempFolderPath} for testing kudulite image`));
+  }
+
+  // Download the source project onto local file system
+  public async downloadSrcBlob(srcBlobName: string): Promise<string> {
+    console.log(chalk.yellow(`Downloading source package ${srcBlobName}...`));
+    await this.srcContainerClient.createIfNotExists();
+
+    const blobClient = this.srcContainerClient.getBlockBlobClient(srcBlobName);
+    const localSrcPath = path.join(this.tempFolderPath, srcBlobName)
+    try {
+      await blobClient.downloadToFile(localSrcPath);
+    } catch (error) {
+      console.log(chalk.red.bold(`Failed to retrieve src zip ${srcBlobName}`));
+      console.log(chalk.red.bold(error));
+      throw error;
+    }
+
+    console.log(chalk.green(`Downloaded source package ${srcBlobName} to ${localSrcPath}`));
+    return localSrcPath;
+  }
+
+  public async generateDestBlobSas(destBlobName: string) {
+    const artifactName = `${this.containerId}_${destBlobName}`;
+    console.log(chalk.yellow(`Generating blob sas uri for artifact storage ${artifactName}...`));
+
+    await this.destContainerClient.createIfNotExists();
+
+    const startsOn = new Date();
+    const expiresOn = new Date();
+    expiresOn.setHours(expiresOn.getHours() + 1);
+
+    const permission = new BlobSASPermissions();
+    permission.create = true;
+    permission.read = true;
+    const credential = this.storageClient.credential as StorageSharedKeyCredential;
+    const sas = generateBlobSASQueryParameters({
+      containerName: this.config.destContainerName,
+      blobName: artifactName,
+      permissions: permission,
+      startsOn,
+      expiresOn
+    }, credential);
+
+    const sasUri = `${this.destContainerClient.url}/${artifactName}?${sas}`;
+    console.log(chalk.green(`Generated destination blob sas ${this.destContainerClient.url}/${artifactName}?sv=...`));
+    return sasUri;
+  }
+
+  public async startContainer(extraEnvVars: Record<string, any> = {}) {
+    console.log(chalk.yellow(`Starting container ${this.containerId} for testing...`));
+
+    // Start container with run command, with environment variables
+    let runCommand = `docker run -p 0:80 -d --name ${this.containerName} -e CONTAINER_NAME=${this.containerName}`;
+    for (const [key, value] of Object.entries(KuduContainer.envVars)) {
+      runCommand += ` -e ${key}="${value}" `;
+    }
+    for (const [key, value] of Object.entries(extraEnvVars)) {
+      runCommand += ` -e ${key}="${value}" `;
+    }
+    runCommand += `${this.config.testImageName}`;
+
+    // Execute docker command
+    if (shell.exec(runCommand).code !== 0) {
+      const errorMessage = `Failed to start ${this.containerName} from image ${this.config.testImageName}`;
+      throw new Error(errorMessage);
+    }
+
+    // Registered current container's port
+    const portCommand = `docker port ${this.containerName}`
+    const portResult = shell.exec(portCommand);
+    if (portResult.code !== 0) {
+      console.log(chalk.red.bold(`Failed to find port for ${this.containerName}`));
+    }
+    const port = portResult.stdout.split(':').reverse()[0];
+    KuduContainer.ports[this.containerName] = parseInt(port);
+
+    console.log(chalk.green(`Created container ${this.containerName} at port ${port}`))
+
+    // Wait for the container to spin up
+    await timeout(5_000);
+  }
+
+  public async applyAppSettings(settings: Record<string, any> = {}) {
+    console.log(chalk.yellow(`Applying application settings to ${this.containerName}...`));
+    await retry(async () => {
+      return await axios.post(`${this.url}/api/settings`, settings, {
+        headers: {
+          'x-ms-site-restricted-token': this.config.siteRestrictedToken,
+          'Content-Type': 'application/json'
+        }
+      });
+    });
+  }
+
+  public async createZipDeploy(zipLocalPath: string) {
+    console.log(chalk.yellow(`Initiate remote build ${zipLocalPath} to ${this.containerId}...`));
+    const file = fs.readFileSync(zipLocalPath);
+    await retry(async () => {
+      return await axios.post(`${this.url}/api/zipdeploy`, file, {
+        headers: {
+          'x-ms-site-restricted-token': this.config.siteRestrictedToken,
+          'Content-Type': 'application/octet-stream'
+        }
+      })
+    });
+
+    console.log(chalk.green(`Remote build finished and uploaded to destination blob sas.`));
+  }
+
+  public killContainer(): void {
+    console.log(chalk.yellow(`Killing container ${this.containerId}...`));
+    const killCommand = `docker kill ${this.containerName}`
+    const killResult = shell.exec(killCommand);
+    if (killResult.code !== 0) {
+      console.log(chalk.red.bold(`Failed to kill container ${this.containerName}`));
+    }
+
+    delete KuduContainer.ports[this.containerName];
+    console.log(chalk.green(`Container ${this.containerName} is deleted`));
+  }
+
+  public async testBuiltArtifact(baseImage: string, blobSasUri: string) {
+    const sanitizedBaseImage = baseImage.replace(/mcr.microsoft.com\/azure-functions\/|\:|\-|\./g, '')
+    const destImageTag = `kudulite/test:${sanitizedBaseImage}_${this.containerId}`;
+    const destContainerName = `${sanitizedBaseImage}_${this.containerId}`;
+    const dockerfileName = `${sanitizedBaseImage}_${this.containerId}.Dockerfile`;
+    const dockerfilePath = path.join(this.tempFolderPath, dockerfileName);
+
+    // Generate docker file in temporary folder
+    console.log(chalk.yellow(`Generating docker file in ${dockerfilePath}...`));
+    fs.writeFileSync(dockerfilePath, `
+FROM ${baseImage}
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \\
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \\
+    WEBSITE_INSTANCE_ID=mock_app_service_environment
+
+RUN apt-get update \\
+    && apt-get install squashfs-tools wget
+
+RUN wget -k -X GET -O ./artifact.squashfs -q '${blobSasUri}' \\
+    && mkdir -p /home/site/wwwroot \\
+    && unsquashfs -d /home/site/wwwroot -f ./artifact.squashfs
+    `);
+
+    // Build runtime image from temporary docker file
+    console.log(chalk.yellow(`Building docker image ${destImageTag}...`));
+    const buildCommand = `docker build -t ${destImageTag} -f ${dockerfilePath} --no-cache .`;
+    const buildResult = shell.exec(buildCommand);
+    if (buildResult.code !== 0) {
+      const errorMessage = `Failed to build runtime image ${destImageTag}`;
+      throw new Error(errorMessage);
+    }
+
+    // Run runtime image in a docker container
+    console.log(chalk.yellow(`Starting docker container ${destContainerName} from ${destImageTag}`));
+    const runCommand = `docker run -p 0:80 -d --name ${destContainerName} ${destImageTag}`;
+    console.log(runCommand);
+    if (shell.exec(runCommand).code !== 0) {
+      const errorMessage = `Failed to start ${destContainerName} from runtime image ${destImageTag}`;
+      throw new Error(errorMessage);
+    }
+
+    // Registered current container's port
+    const portCommand = `docker port ${destContainerName}`;
+    const portResult = shell.exec(portCommand);
+    if (portResult.code !== 0) {
+      console.log(chalk.red.bold(`Failed to find port for ${destContainerName}`));
+    }
+    const port = portResult.stdout.split(':').reverse()[0];
+    KuduContainer.ports[destContainerName] = parseInt(port);
+
+    // Redirect Stdout and Stderr
+    const containerLog = shell.exec(`docker logs -f ${destContainerName}`, {
+      async: true
+    });
+    containerLog.stdout && containerLog.stdout.pipe(process.stdout);
+    containerLog.stderr && containerLog.stderr.pipe(process.stderr);
+
+    // Initiate an HTTP request to /api/HttpTrigger and see if it returns 200
+    console.log(chalk.yellow(`Testing /api/HttpTrigger endpoint in ${destContainerName}`));
+    let success = false;
+    const runtimeHttpTriggerUrl = `http://127.0.0.1:${KuduContainer.ports[destContainerName]}/api/HttpTrigger`;
+    try {
+      await retry(async () => await axios.get(runtimeHttpTriggerUrl));
+      success = true;
+    } catch (error) {
+      console.log(chalk.red.bold(`Test FAILED on ${destContainerName} /api/HttpTrigger : ${error}`));
+      success = false;
+    } finally {
+      // Clean up
+      const killCommand = `docker rm -f ${destContainerName}`;
+      const killResult = shell.exec(killCommand);
+      if (killResult.code !== 0) {
+        console.log(chalk.red.bold(`Failed to kill runtime container ${destContainerName}`));
+      } else {
+        delete KuduContainer.ports[destContainerName];
+      }
+    }
+
+    if (success) {
+      console.log(chalk.green(`Test PASSED on runtime container ${destContainerName}`));
+    } else {
+      throw new Error(`Test FAILED on runtime container ${destContainerName}`);
+    }
+  }
+
+  public get id(): string {
+    return this.containerId;
+  }
+
+  public get name(): string {
+    return this.containerName;
+  }
+
+  public get port(): number | undefined {
+    return KuduContainer.ports[this.containerName];
+  }
+
+  public get url(): string | undefined {
+    return `http://127.0.0.1:${this.port}`
+  }
+
+  private getUniqueContainerId(): string {
+    const date = `${this.createdDate.getUTCFullYear()}${this.createdDate.getUTCMonth() + 1}${this.createdDate.getUTCDate()}`;
+    const time = `${this.createdDate.getUTCHours()}${this.createdDate.getUTCMinutes()}${this.createdDate.getUTCSeconds()}`;
+    const random = Math.floor(Math.random() * 1000000).toString();
+    return `${date}${time}_${random}`;
+  }
+}

--- a/test/kudulite/containers.ts
+++ b/test/kudulite/containers.ts
@@ -4,20 +4,26 @@ import chalk from "chalk";
 import path from "path";
 import shell from "shelljs";
 import { BlobServiceClient, ContainerClient, generateBlobSASQueryParameters, BlobSASPermissions, StorageSharedKeyCredential } from "@azure/storage-blob";
-import { timeout, retry } from './utils';
-import { IConfig } from './interfaces';
+import { timeout, retry, getSiteRestrictedToken, getEncryptedContext } from './utils';
+import { IConfig, IContainerStartContext } from './interfaces';
 
 export class KuduContainer {
   static envVars: Record<string, string> = {
+    WEBSITE_PLACEHOLDER_MODE: '1',
     CONTAINER_ENCRYPTION_KEY: 'MDEyMzQ1Njc4OUFCQ0RFRjAxMjM0NTY3ODlBQkNERUY=',
     WEBSITE_AUTH_ENCRYPTION_KEY: 'E782F47415EEC076F8087729FB30CF1CA1482610C2FA985E4F22531225722205'
   }
 
-  // Map of containerId -> port mapping
+  // Map of container name -> port mapping
   static ports: Record<string, number> = {}
   private createdDate: Date;
+
   private containerId: string;
   private containerName: string;
+  private runtimeContainerName: string;
+  private siteName: string;
+  private siteRestrictedToken: string;
+
   private storageCredential: StorageSharedKeyCredential;
   private storageClient: BlobServiceClient;
   private srcContainerClient: ContainerClient;
@@ -26,14 +32,19 @@ export class KuduContainer {
 
   constructor(private config: IConfig) {
     this.createdDate = new Date();
+
     this.containerId = this.getUniqueContainerId();
     this.containerName = `kudulite${this.containerId}`;
+    this.runtimeContainerName = `runtime${this.containerId}`;
+    this.siteName = `site${this.containerId}`;
+    this.siteRestrictedToken = getSiteRestrictedToken(KuduContainer.envVars.WEBSITE_AUTH_ENCRYPTION_KEY);
+    console.log(chalk.magentaBright.bold(this.siteRestrictedToken));
     this.storageCredential = new StorageSharedKeyCredential(config.storageAccountName, config.storageAccountKey);
     this.storageClient = new BlobServiceClient(`https://${config.storageAccountName}.blob.core.windows.net`, this.storageCredential);
     this.srcContainerClient = this.storageClient.getContainerClient(config.srcContainerName);
     this.destContainerClient = this.storageClient.getContainerClient(config.destContainerName);
+    this.tempFolderPath = path.join('/tmp', 'kudulite_test', `${this.containerId}`);
 
-    this.tempFolderPath = path.join('/tmp', 'kudulite_test', this.containerId);
     fs.mkdirSync(this.tempFolderPath, { recursive: true });
     console.log(chalk.green(`Created temporary folder ${this.tempFolderPath} for testing kudulite image`));
   }
@@ -57,9 +68,9 @@ export class KuduContainer {
     return localSrcPath;
   }
 
-  public async generateDestBlobSas(destBlobName: string) {
-    const artifactName = `${this.containerId}_${destBlobName}`;
-    console.log(chalk.yellow(`Generating blob sas uri for artifact storage ${artifactName}...`));
+  public async getDestBlobSas() {
+    const artifactName = `rfp-latest-${this.siteName}.squashfs`;
+    console.log(chalk.yellow(`Getting blob sas uri for artifact storage ${artifactName}...`));
 
     await this.destContainerClient.createIfNotExists();
 
@@ -80,52 +91,73 @@ export class KuduContainer {
     }, credential);
 
     const sasUri = `${this.destContainerClient.url}/${artifactName}?${sas}`;
-    console.log(chalk.green(`Generated destination blob sas ${this.destContainerClient.url}/${artifactName}?sv=...`));
+    console.log(chalk.green(`Destination blob sas ${this.destContainerClient.url}/${artifactName}?sv=...`));
     return sasUri;
   }
 
-  public async startContainer(extraEnvVars: Record<string, any> = {}) {
+  public async startKuduLiteContainer(extraEnvVars: Record<string, any> = {}): Promise<string> {
+    return this.startContainer(this.config.testImageName, this.containerName, extraEnvVars);
+  }
+
+  public async startRuntimeContainer(image: string, extraEnvVars: Record<string, any> = {}): Promise<string> {
+    return this.startContainer(image, this.runtimeContainerName, extraEnvVars);
+  }
+
+  private async startContainer(image: string, name: string, extraEnvVars: Record<string, any>): Promise<string> {
     console.log(chalk.yellow(`Starting container ${this.containerId} for testing...`));
 
     // Start container with run command, with environment variables
-    let runCommand = `docker run -p 0:80 -d --name ${this.containerName}`;
-    runCommand += ` -e CONTAINER_NAME=${this.containerName}`;
-    runCommand += ` -e WEBSITE_SITE_NAME=${this.containerName}`;
-    runCommand += ` -e WEBSITE_HOSTNAME=${this.containerName}.azurewebsites.net`;
-    for (const [key, value] of Object.entries(KuduContainer.envVars)) {
-      runCommand += ` -e ${key}="${value}"`;
-    }
-    for (const [key, value] of Object.entries(extraEnvVars)) {
-      runCommand += ` -e ${key}="${value}"`;    }
-    runCommand += ` ${this.config.testImageName}`;
+    let runCommand = `docker run -p 0:80 -d --name ${name} -e CONTAINER_NAME="${name}"`;
+    Object.entries(KuduContainer.envVars).forEach(([key, value]) => runCommand += ` -e ${key}="${value}"`);
+    Object.entries(extraEnvVars).forEach(([key, value]) => runCommand += ` -e ${key}="${value}"`);
+    runCommand += ` ${image}`;
+    console.log(runCommand);
 
     // Execute docker command
     if (shell.exec(runCommand).code !== 0) {
-      const errorMessage = `Failed to start ${this.containerName} from image ${this.config.testImageName}`;
+      const errorMessage = `Failed to start ${name} from image ${image}`;
       throw new Error(errorMessage);
     }
 
     // Registered current container's port
-    const portCommand = `docker port ${this.containerName}`
+    const portCommand = `docker port ${name}`
     const portResult = shell.exec(portCommand);
     if (portResult.code !== 0) {
-      console.log(chalk.red.bold(`Failed to find port for ${this.containerName}`));
+      console.log(chalk.red.bold(`Failed to find port for ${name}`));
     }
     const port = portResult.stdout.split(':').reverse()[0];
-    KuduContainer.ports[this.containerName] = parseInt(port);
+    KuduContainer.ports[name] = parseInt(port);
 
-    console.log(chalk.green(`Created container ${this.containerName} at port ${port}`))
+    console.log(chalk.green(`Created container ${name} at port ${port}`))
 
     // Wait for the container to spin up
     await timeout(5_000);
+
+    // Return container name
+    return name;
   }
 
-  public async applyAppSettings(settings: Record<string, any> = {}) {
-    console.log(chalk.yellow(`Applying application settings to ${this.containerName}...`));
+  public async assignContainer(name: string, environmentVariables: Record<string, string>) {
+    console.log(chalk.yellow(`Assign container ${name}...`));
+    const encryptionKey = KuduContainer.envVars.CONTAINER_ENCRYPTION_KEY;
+    const encryptedContext = getEncryptedContext(encryptionKey, {
+      SiteId: parseInt(this.containerId.substring(0, 8)),
+      SiteName: name,
+      Environment: {
+        ...environmentVariables,
+        WEBSITE_SITE_NAME: this.siteName
+      }
+    })
+    console.log(chalk.magentaBright.bold(encryptedContext));
+
+    const baseUrl = `http://127.0.0.1:${KuduContainer.ports[name]}`;
     await retry(async () => {
-      return await axios.post(`${this.url}/api/settings`, settings, {
+      return await axios.post(`${baseUrl}/admin/instance/assign`, {
+        encryptedContext: encryptedContext,
+        isWarmup: false
+      }, {
         headers: {
-          'x-ms-site-restricted-token': this.config.siteRestrictedToken,
+          'x-ms-site-restricted-token': this.siteRestrictedToken,
           'Content-Type': 'application/json'
         },
         // No need to throw exception on user errors
@@ -134,12 +166,28 @@ export class KuduContainer {
     });
   }
 
-  public async getAppSettings(): Promise<Record<string, string>> {
-    console.log(chalk.yellow(`Getting application settings from ${this.containerName}...`));
-    const response = await retry(async () => {
-      return await axios.get(`${this.url}/api/settings`, {
+  public async applyAppSettings(name: string, settings: Record<string, any> = {}) {
+    console.log(chalk.yellow(`Applying application settings to ${name}...`));
+    const baseUrl = `http://127.0.0.1:${KuduContainer.ports[name]}`;
+    await retry(async () => {
+      return await axios.post(`${baseUrl}/api/settings`, settings, {
         headers: {
-          'x-ms-site-restricted-token': this.config.siteRestrictedToken,
+          'x-ms-site-restricted-token': this.siteRestrictedToken,
+          'Content-Type': 'application/json'
+        },
+        // No need to throw exception on user errors
+        validateStatus: (status) => status >= 200 && status <= 499
+      });
+    });
+  }
+
+  public async getAppSettings(name: string): Promise<Record<string, string>> {
+    console.log(chalk.yellow(`Getting application settings from ${name}...`));
+    const baseUrl = `http://127.0.0.1:${KuduContainer.ports[name]}`;
+    const response = await retry(async () => {
+      return await axios.get(`${baseUrl}/api/settings`, {
+        headers: {
+          'x-ms-site-restricted-token': this.siteRestrictedToken,
           'Content-Type': 'application/json'
         },
         // No need to throw exception on user errors
@@ -154,10 +202,11 @@ export class KuduContainer {
     const file = fs.readFileSync(zipLocalPath);
     const params = Object.entries(queryParams).map(([key, value]) => `${key}=${value}`).join('&');
 
+    const baseUrl = `http://127.0.0.1:${KuduContainer.ports[this.containerName]}`;
     await retry(async () => {
-      return await axios.post(`${this.url}/api/zipdeploy?${params}`, file, {
+      return await axios.post(`${baseUrl}/api/zipdeploy?${params}`, file, {
         headers: {
-          'x-ms-site-restricted-token': this.config.siteRestrictedToken,
+          'x-ms-site-restricted-token': this.siteRestrictedToken,
           'Content-Type': 'application/octet-stream'
         }
       })
@@ -178,68 +227,26 @@ export class KuduContainer {
     console.log(chalk.green(`Container ${this.containerName} is deleted`));
   }
 
-  public async testBuiltArtifact(baseImage: string, blobSasUri: string) {
-    const sanitizedBaseImage = baseImage.replace(/mcr.microsoft.com\/azure-functions\/|\:|\-|\./g, '')
-    const destImageTag = `kudulite/test:${sanitizedBaseImage}_${this.containerId}`;
-    const destContainerName = `${sanitizedBaseImage}_${this.containerId}`;
-    const dockerfileName = `${sanitizedBaseImage}_${this.containerId}.Dockerfile`;
-    const dockerfilePath = path.join(this.tempFolderPath, dockerfileName);
+  public async testBuiltArtifact(baseImage: string, environmentVariables: Record<string, string>) {
+    const destContainerName = this.runtimeContainerName;
 
-    // Generate docker file in temporary folder
-    console.log(chalk.yellow(`Generating docker file in ${dockerfilePath}...`));
-    fs.writeFileSync(dockerfilePath, `
-FROM ${baseImage}
+    // Pull down the base image and kick start the runtime in it
+    console.log(chalk.yellow(`Testing built artifact with ${baseImage} on ${destContainerName}}`));
+    const baseUrl = await this.startRuntimeContainer(baseImage, environmentVariables);
 
-ENV AzureWebJobsScriptRoot=/home/site/wwwroot \\
-    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \\
-    WEBSITE_INSTANCE_ID=mock_app_service_environment
-
-RUN apt-get update \\
-    && apt-get install squashfs-tools wget
-
-RUN wget -k -X GET -O ./artifact.squashfs -q '${blobSasUri}' \\
-    && mkdir -p /home/site/wwwroot \\
-    && unsquashfs -d /home/site/wwwroot -f ./artifact.squashfs
-    `);
-
-    // Build runtime image from temporary docker file
-    console.log(chalk.yellow(`Building docker image ${destImageTag}...`));
-    const buildCommand = `docker build -t ${destImageTag} -f ${dockerfilePath} --no-cache .`;
-    const buildResult = shell.exec(buildCommand);
-    if (buildResult.code !== 0) {
-      const errorMessage = `Failed to build runtime image ${destImageTag}`;
-      throw new Error(errorMessage);
-    }
-
-    // Run runtime image in a docker container
-    console.log(chalk.yellow(`Starting docker container ${destContainerName} from ${destImageTag}`));
-    const runCommand = `docker run -p 0:80 -d --name ${destContainerName} ${destImageTag}`;
-    console.log(runCommand);
-    if (shell.exec(runCommand).code !== 0) {
-      const errorMessage = `Failed to start ${destContainerName} from runtime image ${destImageTag}`;
-      throw new Error(errorMessage);
-    }
-
-    // Registered current container's port
-    const portCommand = `docker port ${destContainerName}`;
-    const portResult = shell.exec(portCommand);
-    if (portResult.code !== 0) {
-      console.log(chalk.red.bold(`Failed to find port for ${destContainerName}`));
-    }
-    const port = portResult.stdout.split(':').reverse()[0];
-    KuduContainer.ports[destContainerName] = parseInt(port);
-
-    // Redirect Stdout and Stderr
-    const containerLog = shell.exec(`docker logs -f ${destContainerName}`, {
-      async: true
-    });
+    // Redirect stdout and stderr
+    const containerLog = shell.exec(`docker logs -f ${destContainerName}`, { async: true });
     containerLog.stdout && containerLog.stdout.pipe(process.stdout);
     containerLog.stderr && containerLog.stderr.pipe(process.stderr);
 
+    // Specialize container
+    console.log(chalk.yellow(`Specializing /admin/instance/assign endpoint in ${destContainerName}...`));
+    await this.assignContainer(this.runtimeContainerName, environmentVariables);
+
     // Initiate an HTTP request to /api/HttpTrigger and see if it returns 200
-    console.log(chalk.yellow(`Testing /api/HttpTrigger endpoint in ${destContainerName}`));
+    console.log(chalk.yellow(`Testing /api/HttpTrigger endpoint in ${destContainerName}...`));
     let success = false;
-    const runtimeHttpTriggerUrl = `http://127.0.0.1:${KuduContainer.ports[destContainerName]}/api/HttpTrigger`;
+    const runtimeHttpTriggerUrl = `${baseUrl}/api/HttpTrigger`;
     try {
       await retry(async () => await axios.get(runtimeHttpTriggerUrl));
       success = true;
@@ -248,6 +255,7 @@ RUN wget -k -X GET -O ./artifact.squashfs -q '${blobSasUri}' \\
       success = false;
     } finally {
       // Clean up container
+      console.log(chalk.yellow(`Cleaning up container ${destContainerName}...`));
       const killCommand = `docker rm -f ${destContainerName}`;
       const killResult = shell.exec(killCommand);
       if (killResult.code !== 0) {
@@ -255,10 +263,11 @@ RUN wget -k -X GET -O ./artifact.squashfs -q '${blobSasUri}' \\
       }
 
       // Clean up docker image
-      const rmiCommand = `docker rmi ${destImageTag}`;
+      console.log(chalk.yellow(`Cleaning up image ${baseImage}...`));
+      const rmiCommand = `docker rmi ${baseImage}`;
       const rmiResult = shell.exec(rmiCommand);
       if (rmiResult.code !== 0) {
-        console.log(chalk.red.bold(`Failed to remove runtime image ${destImageTag}`));
+        console.log(chalk.red.bold(`Failed to remove runtime image ${baseImage}`));
       }
 
       delete KuduContainer.ports[destContainerName];
@@ -271,26 +280,10 @@ RUN wget -k -X GET -O ./artifact.squashfs -q '${blobSasUri}' \\
     }
   }
 
-  public get id(): string {
-    return this.containerId;
-  }
-
-  public get name(): string {
-    return this.containerName;
-  }
-
-  public get port(): number | undefined {
-    return KuduContainer.ports[this.containerName];
-  }
-
-  public get url(): string | undefined {
-    return `http://127.0.0.1:${this.port}`
-  }
-
   private getUniqueContainerId(): string {
-    const date = `${this.createdDate.getUTCFullYear()}${this.createdDate.getUTCMonth() + 1}${this.createdDate.getUTCDate()}`;
-    const time = `${this.createdDate.getUTCHours()}${this.createdDate.getUTCMinutes()}${this.createdDate.getUTCSeconds()}`;
-    const random = Math.floor(Math.random() * 1000000).toString();
-    return `${date}${time}_${random}`;
+    //YYYYMMDDhhmmss + random 3 digits
+    const datetime = this.createdDate.toISOString().substring(0, 19).replace(/T|Z|\:|\.|\-/g, '')
+    const random = Math.floor(Math.random() * 1000).toString();
+    return `${datetime}${random}`;
   }
 }

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -40,12 +40,6 @@ async function initialize(): Promise<IConfig> {
     process.exit(1);
   }
 
-  if (!process.env.SITE_RESTRICTED_TOKEN) {
-    console.error(chalk.red.bold("process.env.SITE_RESTRICTED_TOKEN is required"));
-    console.error(chalk.red.bold("This is the credential for calling the POST /api/settings to setup remote build"));
-    process.exit(1);
-  }
-
   const storageConnectionString = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;' +
     `AccountName=${process.env.STORAGE_ACCOUNT_NAME};` +
     `AccountKey=${process.env.STORAGE_ACCOUNT_KEY}`;
@@ -54,10 +48,9 @@ async function initialize(): Promise<IConfig> {
     testImageName: process.argv.reverse()[0],
     storageAccountName: process.env.STORAGE_ACCOUNT_NAME,
     storageAccountKey: process.env.STORAGE_ACCOUNT_KEY,
-    siteRestrictedToken: process.env.SITE_RESTRICTED_TOKEN,
     storageConnectionString: storageConnectionString,
     srcContainerName: 'testsrc',
-    destContainerName: 'testdest',
+    destContainerName: 'scm-releases',
   }
 }
 
@@ -79,10 +72,12 @@ async function main() {
 
   try {
     await Promise.all([
-      testHost20Python36.run(config),
       /*
+      testHost20Python36.run(config),
       testHost20Python37.run(config),
+      */
       testHost30Python36.run(config),
+      /*
       testHost30Python37.run(config),
       testHost30Python38.run(config),
       testHost20Node8.run(config),

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -40,17 +40,31 @@ async function initialize(): Promise<IConfig> {
     process.exit(1);
   }
 
+  if (!process.env.V2_RUNTIME_VERSION) {
+    console.error(chalk.red.bold("process.env.V2_RUNTIME_VERSION is required"));
+    console.error(chalk.red.bold("This defines the v2 runtime image version tags (e.g. 2.0.14248)"));
+    process.exit(1);
+  }
+
+  if (!process.env.V3_RUNTIME_VERSION) {
+    console.error(chalk.red.bold("process.env.V3_RUNTIME_VERSION is required"));
+    console.error(chalk.red.bold("This defines the v3 runtime image version tags (e.g. 3.0.14287)"));
+    process.exit(1);
+  }
+
   const storageConnectionString = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;' +
     `AccountName=${process.env.STORAGE_ACCOUNT_NAME};` +
     `AccountKey=${process.env.STORAGE_ACCOUNT_KEY}`;
 
   return {
-    testImageName: process.argv.reverse()[0],
+    kuduliteImage: process.argv.reverse()[0],
     storageAccountName: process.env.STORAGE_ACCOUNT_NAME,
     storageAccountKey: process.env.STORAGE_ACCOUNT_KEY,
+    v2RuntimeVersion: process.env.V2_RUNTIME_VERSION,
+    v3RuntimeVersion: process.env.V3_RUNTIME_VERSION,
     storageConnectionString: storageConnectionString,
     srcContainerName: 'testsrc',
-    destContainerName: 'scm-releases',
+    destContainerName: 'scm-releases'
   }
 }
 
@@ -72,19 +86,15 @@ async function main() {
 
   try {
     await Promise.all([
-      /*
-      testHost20Python36.run(config),
-      testHost20Python37.run(config),
-      */
-      testHost30Python36.run(config),
-      /*
-      testHost30Python37.run(config),
-      testHost30Python38.run(config),
-      testHost20Node8.run(config),
-      testHost20Node10.run(config),
-      testHost30Node10.run(config),
-      testHost30Node12.run(config)
-      */
+      testHost20Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`),
+      testHost20Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-python3.7`),
+      testHost20Node8.run(config, 'KuduLiteNode8.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`),
+      testHost20Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-node10`),
+      testHost30Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`),
+      testHost30Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`),
+      testHost30Python38.run(config, 'KuduLitePython38.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`),
+      testHost30Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`),
+      testHost30Node12.run(config, 'KuduLiteNode12.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-node12`),
     ]);
   } catch (error) {
     console.log(chalk.red.bold(error));

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -1,0 +1,93 @@
+import chalk from "chalk";
+import { IConfig } from './interfaces';
+import {
+  Host20Python36,
+  Host20Python37,
+  Host30Python36,
+  Host30Python37,
+  Host30Python38,
+  Host20Node8,
+  Host20Node10,
+  Host30Node10,
+  Host30Node12
+} from './testcases'
+
+// Flow
+// 1. Developer upload src.zip (e.g. python36_src.zip) to source container
+// 2. The program will first initialize a KuduLite container for remote build service
+// 3. The program will download the source project and run /api/zipdeploy
+// 4. The final artifact will be built onto a destination container
+// 5. The test will spin up a runtime image and extract artifact content in /home/site/wwwroot
+// 6. The test will check if the /api/HttpTrigger endpoint returns 200
+
+async function initialize(): Promise<IConfig> {
+  if (process.argv.length < 3) {
+    console.error(chalk.red.bold("Usage: ts-node kudulite <image-name>"));
+    console.error(chalk.red.bold("Example:"));
+    console.error(chalk.red.bold("    ts-node kudulite mcr.microsoft.com/azure-functions/kudulite:kudu-2.11"));
+    process.exit(1);
+  }
+
+  if (!process.env.STORAGE_ACCOUNT_NAME) {
+    console.error(chalk.red.bold("process.env.STORAGE_ACCOUNT_NAME is required"));
+    console.error(chalk.red.bold("This is the storage account name to the src project zips and dest artifacts"));
+    process.exit(1);
+  }
+
+  if (!process.env.STORAGE_ACCOUNT_KEY) {
+    console.error(chalk.red.bold("process.env.STORAGE_ACCOUNT_KEY is required"));
+    console.error(chalk.red.bold("This is the storage account key to the src project zips and dest artifacts"));
+    process.exit(1);
+  }
+
+  if (!process.env.SITE_RESTRICTED_TOKEN) {
+    console.error(chalk.red.bold("process.env.SITE_RESTRICTED_TOKEN is required"));
+    console.error(chalk.red.bold("This is the credential for calling the POST /api/settings to setup remote build"));
+    process.exit(1);
+  }
+
+  return {
+    testImageName: process.argv.reverse()[0],
+    storageAccountName: process.env.STORAGE_ACCOUNT_NAME,
+    storageAccountKey: process.env.STORAGE_ACCOUNT_KEY,
+    siteRestrictedToken: process.env.SITE_RESTRICTED_TOKEN,
+    srcContainerName: 'testsrc',
+    destContainerName: 'testdest',
+  }
+}
+
+async function main() {
+  const config: IConfig = await initialize();
+
+  // Python
+  const testHost20Python36 = new Host20Python36();
+  const testHost20Python37 = new Host20Python37();
+  const testHost30Python36 = new Host30Python36();
+  const testHost30Python37 = new Host30Python37();
+  const testHost30Python38 = new Host30Python38();
+
+  // Node
+  const testHost20Node8 = new Host20Node8();
+  const testHost20Node10 = new Host20Node10();
+  const testHost30Node10 = new Host30Node10();
+  const testHost30Node12 = new Host30Node12();
+
+  try {
+    await Promise.all([
+      testHost20Python36.run(config),
+      testHost20Python37.run(config),
+      testHost30Python36.run(config),
+      testHost30Python37.run(config),
+      testHost30Python38.run(config),
+      testHost20Node8.run(config),
+      testHost20Node10.run(config),
+      testHost30Node10.run(config),
+      testHost30Node12.run(config)
+    ]);
+  } catch (error) {
+    console.log(chalk.red.bold(error));
+    process.exit(1)
+  }
+}
+
+main();

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -46,11 +46,16 @@ async function initialize(): Promise<IConfig> {
     process.exit(1);
   }
 
+  const storageConnectionString = 'DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;' +
+    `AccountName=${process.env.STORAGE_ACCOUNT_NAME};` +
+    `AccountKey=${process.env.STORAGE_ACCOUNT_KEY}`;
+
   return {
     testImageName: process.argv.reverse()[0],
     storageAccountName: process.env.STORAGE_ACCOUNT_NAME,
     storageAccountKey: process.env.STORAGE_ACCOUNT_KEY,
     siteRestrictedToken: process.env.SITE_RESTRICTED_TOKEN,
+    storageConnectionString: storageConnectionString,
     srcContainerName: 'testsrc',
     destContainerName: 'testdest',
   }
@@ -75,6 +80,7 @@ async function main() {
   try {
     await Promise.all([
       testHost20Python36.run(config),
+      /*
       testHost20Python37.run(config),
       testHost30Python36.run(config),
       testHost30Python37.run(config),
@@ -83,6 +89,7 @@ async function main() {
       testHost20Node10.run(config),
       testHost30Node10.run(config),
       testHost30Node12.run(config)
+      */
     ]);
   } catch (error) {
     console.log(chalk.red.bold(error));

--- a/test/kudulite/interfaces.ts
+++ b/test/kudulite/interfaces.ts
@@ -1,11 +1,27 @@
+export interface IRuntimeImages {
+  // Python
+  host20python36mesh: string;
+  host20python37mesh: string;
+  host30python36mesh: string;
+  host30python37mesh: string;
+  host30python38mesh: string;
+
+  // Node
+}
+
 export interface IConfig {
   testImageName: string;
   storageAccountName: string;
   storageAccountKey: string;
   storageConnectionString: string;
-  siteRestrictedToken: string;
   srcContainerName: string;
   destContainerName: string;
+}
+
+export interface IContainerStartContext {
+  SiteId: number;
+  SiteName: string;
+  Environment: Record<string, string>
 }
 
 export interface ITestCase {

--- a/test/kudulite/interfaces.ts
+++ b/test/kudulite/interfaces.ts
@@ -1,0 +1,12 @@
+export interface IConfig {
+  testImageName: string;
+  storageAccountName: string;
+  storageAccountKey: string;
+  siteRestrictedToken: string;
+  srcContainerName: string;
+  destContainerName: string;
+}
+
+export interface ITestCase {
+  run: (config: IConfig) => Promise<void>;
+}

--- a/test/kudulite/interfaces.ts
+++ b/test/kudulite/interfaces.ts
@@ -1,21 +1,12 @@
-export interface IRuntimeImages {
-  // Python
-  host20python36mesh: string;
-  host20python37mesh: string;
-  host30python36mesh: string;
-  host30python37mesh: string;
-  host30python38mesh: string;
-
-  // Node
-}
-
 export interface IConfig {
-  testImageName: string;
+  kuduliteImage: string;
   storageAccountName: string;
   storageAccountKey: string;
   storageConnectionString: string;
   srcContainerName: string;
   destContainerName: string;
+  v2RuntimeVersion: string;
+  v3RuntimeVersion: string;
 }
 
 export interface IContainerStartContext {
@@ -25,5 +16,5 @@ export interface IContainerStartContext {
 }
 
 export interface ITestCase {
-  run: (config: IConfig) => Promise<void>;
+  run: (config: IConfig, srcPackage: string, runtimeImage: string) => Promise<void>;
 }

--- a/test/kudulite/interfaces.ts
+++ b/test/kudulite/interfaces.ts
@@ -2,6 +2,7 @@ export interface IConfig {
   testImageName: string;
   storageAccountName: string;
   storageAccountKey: string;
+  storageConnectionString: string;
   siteRestrictedToken: string;
   srcContainerName: string;
   destContainerName: string;

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -1,6 +1,7 @@
 import { ITestCase, IConfig } from "./interfaces";
 import { KuduContainer } from "./containers";
 
+// Host 2.0 Python36 /api/zipdeploy
 export class Host20Python36 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
@@ -25,6 +26,7 @@ export class Host20Python36 implements ITestCase {
   }
 }
 
+// Host 2.0 Python37 /api/zipdeploy
 export class Host20Python37 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
@@ -49,10 +51,10 @@ export class Host20Python37 implements ITestCase {
   }
 }
 
+// Host 3.0 Python36 /api/zipdeploy?overwriteWebsiteRunFromPackage=true
 export class Host30Python36 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host30_python36_dest.zip');
     const settings = {
       "ENABLE_ORYX_BUILD": true,
       "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
@@ -62,14 +64,14 @@ export class Host30Python36 implements ITestCase {
       "FRAMEWORK": "python",
       "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
       "FRAMEWORK_VERSION": "3.6",
-      "SCM_RUN_FROM_PACKAGE": destSas
+      "AzureWebJobsStorage": config.storageConnectionString
     }
     await container.startContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
     await container.applyAppSettings(settings);
-    await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.6', destSas);
-    container.killContainer();
+    await container.createZipDeploy(localSrcPath, { 'overwriteWebsiteRunFromPackage': 'true' });
+    //await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.6', destSas);
+    //container.killContainer();
   }
 }
 

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -3,7 +3,7 @@ import { KuduContainer } from "./containers";
 
 // Host 2.0 Python36 /api/zipdeploy
 export class Host20Python36 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -18,17 +18,17 @@ export class Host20Python36 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:2.0-python3.6', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 // Host 2.0 Python37 /api/zipdeploy
 export class Host20Python37 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -43,17 +43,17 @@ export class Host20Python37 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLitePython37.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 // Host 3.0 Python36 /api/zipdeploy?overwriteWebsiteRunFromPackage=true
 export class Host30Python36 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -65,22 +65,19 @@ export class Host30Python36 implements ITestCase {
       "FRAMEWORK": "python",
       "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
       "FRAMEWORK_VERSION": "3.6",
-      // Used by kudulite to emit built artifact
-      "AzureWebJobsStorage": config.storageConnectionString,
-      // Used by runtime image to initialize function project
-      "WEBSITE_RUN_FROM_PACKAGE": destSas
+      "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
     await container.assignContainer(kuduliteContainerName, settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
-    await container.createZipDeploy(localSrcPath, { 'overwriteWebsiteRunFromPackage': 'true' });
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/mesh:3.0.14287', settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 export class Host30Python37 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -95,16 +92,16 @@ export class Host30Python37 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLitePython37.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 export class Host30Python38 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -119,16 +116,16 @@ export class Host30Python38 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLitePython38.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.8', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 export class Host20Node8 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -143,16 +140,16 @@ export class Host20Node8 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode8.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node8', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 export class Host20Node10 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -167,16 +164,16 @@ export class Host20Node10 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode10.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node10', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 export class Host30Node10 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -191,16 +188,16 @@ export class Host30Node10 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode10.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node10', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }
 
 export class Host30Node12 implements ITestCase {
-  public async run(config: IConfig): Promise<void> {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
@@ -215,10 +212,10 @@ export class Host30Node12 implements ITestCase {
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
-    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode12.zip');
-    await container.applyAppSettings(kuduliteContainerName, settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node12', settings);
+    await container.testBuiltArtifact(runtimeImage, settings);
     container.killContainer();
   }
 }

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -1,0 +1,218 @@
+import { ITestCase, IConfig } from "./interfaces";
+import { KuduContainer } from "./containers";
+
+export class Host20Python36 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host20_python36_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~2",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
+      "FRAMEWORK_VERSION": "3.6",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:2.0-python3.6', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host20Python37 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host20_python37_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~2",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.7",
+      "FRAMEWORK_VERSION": "3.7",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLitePython37.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host30Python36 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host30_python36_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
+      "FRAMEWORK_VERSION": "3.6",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.6', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host30Python37 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host30_python37_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.7",
+      "FRAMEWORK_VERSION": "3.7",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLitePython37.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host30Python38 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host30_python38_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.8",
+      "FRAMEWORK_VERSION": "3.8",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLitePython38.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.8', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host20Node8 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host20_node8_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~2",
+      "FUNCTIONS_WORKER_RUNTIME": "node",
+      "FRAMEWORK": "node",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "8",
+      "FRAMEWORK_VERSION": "8",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode8.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node8', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host20Node10 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host20_node10_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~2",
+      "FUNCTIONS_WORKER_RUNTIME": "node",
+      "FRAMEWORK": "node",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "10",
+      "FRAMEWORK_VERSION": "10",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode10.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node10', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host30Node10 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host30_node10_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "node",
+      "FRAMEWORK": "node",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "10",
+      "FRAMEWORK_VERSION": "10",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode10.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node10', destSas);
+    container.killContainer();
+  }
+}
+
+export class Host30Node12 implements ITestCase {
+  public async run(config: IConfig): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.generateDestBlobSas('host30_node12_dest.zip');
+    const settings = {
+      "ENABLE_ORYX_BUILD": true,
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
+      "ENABLE_DYNAMIC_INSTALL": true,
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "node",
+      "FRAMEWORK": "node",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "12",
+      "FRAMEWORK_VERSION": "12",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    await container.startContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob('KuduLiteNode12.zip');
+    await container.applyAppSettings(settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node12', destSas);
+    container.killContainer();
+  }
+}

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -5,11 +5,11 @@ import { KuduContainer } from "./containers";
 export class Host20Python36 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host20_python36_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~2",
       "FUNCTIONS_WORKER_RUNTIME": "python",
       "FRAMEWORK": "python",
@@ -17,11 +17,11 @@ export class Host20Python36 implements ITestCase {
       "FRAMEWORK_VERSION": "3.6",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:2.0-python3.6', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:2.0-python3.6', settings);
     container.killContainer();
   }
 }
@@ -30,11 +30,11 @@ export class Host20Python36 implements ITestCase {
 export class Host20Python37 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host20_python37_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~2",
       "FUNCTIONS_WORKER_RUNTIME": "python",
       "FRAMEWORK": "python",
@@ -42,11 +42,11 @@ export class Host20Python37 implements ITestCase {
       "FRAMEWORK_VERSION": "3.7",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLitePython37.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', settings);
     container.killContainer();
   }
 }
@@ -55,34 +55,38 @@ export class Host20Python37 implements ITestCase {
 export class Host30Python36 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~3",
       "FUNCTIONS_WORKER_RUNTIME": "python",
       "FRAMEWORK": "python",
       "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
       "FRAMEWORK_VERSION": "3.6",
-      "AzureWebJobsStorage": config.storageConnectionString
+      // Used by kudulite to emit built artifact
+      "AzureWebJobsStorage": config.storageConnectionString,
+      // Used by runtime image to initialize function project
+      "WEBSITE_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    await container.assignContainer(kuduliteContainerName, settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLitePython36.zip');
-    await container.applyAppSettings(settings);
     await container.createZipDeploy(localSrcPath, { 'overwriteWebsiteRunFromPackage': 'true' });
-    //await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.6', destSas);
-    //container.killContainer();
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/mesh:3.0.14287', settings);
+    container.killContainer();
   }
 }
 
 export class Host30Python37 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host30_python37_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~3",
       "FUNCTIONS_WORKER_RUNTIME": "python",
       "FRAMEWORK": "python",
@@ -90,11 +94,11 @@ export class Host30Python37 implements ITestCase {
       "FRAMEWORK_VERSION": "3.7",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLitePython37.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.7', settings);
     container.killContainer();
   }
 }
@@ -102,11 +106,11 @@ export class Host30Python37 implements ITestCase {
 export class Host30Python38 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host30_python38_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~3",
       "FUNCTIONS_WORKER_RUNTIME": "python",
       "FRAMEWORK": "python",
@@ -114,11 +118,11 @@ export class Host30Python38 implements ITestCase {
       "FRAMEWORK_VERSION": "3.8",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLitePython38.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.8', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/python:3.0-python3.8', settings);
     container.killContainer();
   }
 }
@@ -126,11 +130,11 @@ export class Host30Python38 implements ITestCase {
 export class Host20Node8 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host20_node8_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~2",
       "FUNCTIONS_WORKER_RUNTIME": "node",
       "FRAMEWORK": "node",
@@ -138,11 +142,11 @@ export class Host20Node8 implements ITestCase {
       "FRAMEWORK_VERSION": "8",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLiteNode8.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node8', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node8', settings);
     container.killContainer();
   }
 }
@@ -150,11 +154,11 @@ export class Host20Node8 implements ITestCase {
 export class Host20Node10 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host20_node10_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~2",
       "FUNCTIONS_WORKER_RUNTIME": "node",
       "FRAMEWORK": "node",
@@ -162,11 +166,11 @@ export class Host20Node10 implements ITestCase {
       "FRAMEWORK_VERSION": "10",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLiteNode10.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node10', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:2.0-node10', settings);
     container.killContainer();
   }
 }
@@ -174,11 +178,11 @@ export class Host20Node10 implements ITestCase {
 export class Host30Node10 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host30_node10_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~3",
       "FUNCTIONS_WORKER_RUNTIME": "node",
       "FRAMEWORK": "node",
@@ -186,11 +190,11 @@ export class Host30Node10 implements ITestCase {
       "FRAMEWORK_VERSION": "10",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLiteNode10.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node10', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node10', settings);
     container.killContainer();
   }
 }
@@ -198,11 +202,11 @@ export class Host30Node10 implements ITestCase {
 export class Host30Node12 implements ITestCase {
   public async run(config: IConfig): Promise<void> {
     const container = new KuduContainer(config);
-    const destSas = await container.generateDestBlobSas('host30_node12_dest.zip');
+    const destSas = await container.getDestBlobSas();
     const settings = {
-      "ENABLE_ORYX_BUILD": true,
-      "SCM_DO_BUILD_DURING_DEPLOYMENT": true,
-      "ENABLE_DYNAMIC_INSTALL": true,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
       "FUNCTIONS_EXTENSION_VERSION": "~3",
       "FUNCTIONS_WORKER_RUNTIME": "node",
       "FRAMEWORK": "node",
@@ -210,11 +214,11 @@ export class Host30Node12 implements ITestCase {
       "FRAMEWORK_VERSION": "12",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
-    await container.startContainer(settings);
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob('KuduLiteNode12.zip');
-    await container.applyAppSettings(settings);
+    await container.applyAppSettings(kuduliteContainerName, settings);
     await container.createZipDeploy(localSrcPath);
-    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node12', destSas);
+    await container.testBuiltArtifact('mcr.microsoft.com/azure-functions/node:3.0-node12', settings);
     container.killContainer();
   }
 }

--- a/test/kudulite/utils.ts
+++ b/test/kudulite/utils.ts
@@ -1,0 +1,33 @@
+import { AxiosResponse } from "axios";
+import chalk from "chalk";
+
+export const timeout = (ms: number) => new Promise(res => setTimeout(res, ms));
+
+export const retry = async (
+  axiosFunc: () => Promise<AxiosResponse<any>>,
+  interval: number = 5_000,
+  count: number = 5,
+): Promise<AxiosResponse<any>> => {
+  let trials = 0;
+  let error = false;
+  do {
+    try {
+      const response = await axiosFunc();
+      const method = (response.config.method as string).toUpperCase();
+      const url = response.config.url;
+      const status = response.status;
+      console.log(chalk.green(`[${method}] ${url} => ${status}`));
+      error = false;
+      return Promise.resolve<AxiosResponse<any>>(response);
+    } catch (e) {
+      console.error(chalk.red(e));
+      error = true;
+      if (trials >= count) {
+        throw e;
+      } else {
+        await timeout(interval);
+        trials++;
+      }
+    }
+  } while (true);
+};

--- a/test/kudulite/utils.ts
+++ b/test/kudulite/utils.ts
@@ -50,14 +50,24 @@ export const toCSharpTick = (datetime: Date): number => {
   return datetime.getTime() * 10000 + 621355680000000000;
 }
 
-export const getSiteRestrictedToken = (authEncryptionKey: string) => {
+// WEBSITE_AUTH_ENCRYPTION_KEY x-ms-site-restricted-token
+export const getSiteRestrictedTokenFromHex = (authEncryptionKey: string) => {
   const current = new Date();
   const expiry = new Date(current.getFullYear(), current.getMonth(), current.getDate() + 2);
   const encryptionKey = CryptoJS.enc.Hex.parse(authEncryptionKey);
-  return encryptContext(encryptionKey, `exp=${toCSharpTick(expiry)}`)
+  return encryptContext(encryptionKey, `exp=${toCSharpTick(expiry)}`);
 };
 
-export const getEncryptedContext = (containerKey: string, context: IContainerStartContext) => {
+// CONTAINER_ENCRYPTION_KEY x-ms-site-restricted-token
+export const getSiteRestirctedTokenFromBase64 = (containerKey: string) => {
+  const current = new Date();
+  const expiry = new Date(current.getFullYear(), current.getMonth(), current.getDate() + 2);
+  const encryptionKey = CryptoJS.enc.Base64.parse(containerKey);
+  return encryptContext(encryptionKey, `exp=${toCSharpTick(expiry)}`);
+};
+
+// CONTAINER_ENCRYPTION_KEY /admin/instance/assign
+export const getEncryptedContextFromBase64 = (containerKey: string, context: IContainerStartContext) => {
   const containerKeyBytes = CryptoJS.enc.Base64.parse(containerKey);
   const result = encryptContext(containerKeyBytes, JSON.stringify(context));
   return result;

--- a/test/kudulite/utils.ts
+++ b/test/kudulite/utils.ts
@@ -1,5 +1,7 @@
 import { AxiosResponse } from "axios";
+import CryptoJS from "crypto-js";
 import chalk from "chalk";
+import { IContainerStartContext } from "./interfaces";
 
 export const timeout = (ms: number) => new Promise(res => setTimeout(res, ms));
 
@@ -30,4 +32,33 @@ export const retry = async (
       }
     }
   } while (true);
+};
+
+export const encryptContext = (encryptionKey: CryptoJS.WordArray, plainText: string) => {
+  const plainTextUtf8Bytes = CryptoJS.enc.Utf8.parse(plainText);
+  const aesEncrypted = CryptoJS.AES.encrypt(plainTextUtf8Bytes, encryptionKey, {
+    iv: CryptoJS.enc.Utf8.parse('0123456789abcdef')
+  });
+  const aesIvBase64 = CryptoJS.enc.Base64.stringify(aesEncrypted.iv);
+  const aesEncryptedMessageBase64 = CryptoJS.enc.Base64.stringify(aesEncrypted.ciphertext);
+  const aesKeySHA256Base64 = CryptoJS.SHA256(aesEncrypted.key as string).toString(CryptoJS.enc.Base64);
+
+  return `${aesIvBase64}.${aesEncryptedMessageBase64}.${aesKeySHA256Base64}`;
+};
+
+export const toCSharpTick = (datetime: Date): number => {
+  return datetime.getTime() * 10000 + 621355680000000000;
+}
+
+export const getSiteRestrictedToken = (authEncryptionKey: string) => {
+  const current = new Date();
+  const expiry = new Date(current.getFullYear(), current.getMonth(), current.getDate() + 2);
+  const encryptionKey = CryptoJS.enc.Hex.parse(authEncryptionKey);
+  return encryptContext(encryptionKey, `exp=${toCSharpTick(expiry)}`)
+};
+
+export const getEncryptedContext = (containerKey: string, context: IContainerStartContext) => {
+  const containerKeyBytes = CryptoJS.enc.Base64.parse(containerKey);
+  const result = encryptContext(containerKeyBytes, JSON.stringify(context));
+  return result;
 };

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -4,6 +4,176 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
+      "integrity": "sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.3.tgz",
+      "integrity": "sha512-A4xigW0YZZpkj1zK7dKuzbBpGwnhEcRk6WWuIshdHC32raR3EQ1j6VA9XZqE+RFsUgH6OAmIK5BWIz+mZjnd6Q==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@opentelemetry/api": "^0.6.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.1.6.tgz",
+      "integrity": "sha512-/C+qNzhwlLKt0F6SjaBEyY2pwZvwL2LviyS5PHlCh77qWuTF1sETmYAINM88BCN+kke+UlECK4YOQaAjJwyHvQ==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.1.3",
+        "@azure/core-tracing": "1.0.0-preview.9",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.0.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.1.0",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "@azure/core-tracing": {
+          "version": "1.0.0-preview.9",
+          "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.9.tgz",
+          "integrity": "sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==",
+          "requires": {
+            "@opencensus/web-types": "0.0.7",
+            "@opentelemetry/api": "^0.10.2",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
+          "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+          "requires": {
+            "@opentelemetry/context-base": "^0.10.2"
+          }
+        },
+        "@opentelemetry/context-base": {
+          "version": "0.10.2",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
+          "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw=="
+        }
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.2.tgz",
+      "integrity": "sha512-Yr0JD7GKryOmbcb5wHCQoQ4KCcH5QJWRNorofid+UvudLaxnbCfvKh/cUfQsGUqRjO9L/Bw4X7FP824DcHdMxw==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.1.1",
+        "events": "^3.0.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.1.tgz",
+      "integrity": "sha512-hqEJBEGKan4YdOaL9ZG/GRG6PXaFd/Wb3SSjQW4LWotZzgl6xqG00h6wmkrpd2NNkbBkD1erLHBO3lPHApv+iQ==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.8",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.8.tgz",
+      "integrity": "sha512-ZKUpCd7Dlyfn7bdc+/zC/sf0aRIaNQMDuSj2RhYRFe3p70hVAnYGp3TX4cnG2yoEALp/LTj/XnZGQ8Xzf6Ja/Q==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.6.1",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-g2qLDgvmhyIxR3JVS8N67CyIOeFRKQlX/llxYJQr1OSGQqM3HTpVP8MjmjcEKbL/OIt2N9C9UFaNQuKOw1laOA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.2.0-preview.1",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.2.0-preview.1.tgz",
+      "integrity": "sha512-4igL7EPn0pxDy7uUBTnx/kxqWK3ZXO7HkIEx919m+rCXLsCQzvLrDd7YGn8VI/bhO2JrPTM8vxPu7bNYC4aEwQ==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.1.1",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.8",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.6.1",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.6.1.tgz",
+      "integrity": "sha512-wpufGZa7tTxw7eAsjXJtiyIQ42IWQdX9iUQp7ACJcKo1hCtuhLU+K2Nv1U6oRwT1oAlZTE6m4CgWKZBhOiau3Q==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.6.1"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.6.1.tgz",
+      "integrity": "sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -34,12 +204,29 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
       "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/shelljs": {
       "version": "0.8.6",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.6.tgz",
       "integrity": "sha512-svx2eQS268awlppL/P8wgDLBrsDXdKznABHJcuqXyWpSKJgE1s2clXlBvAwbO/lehTmG06NtEWJRkAk4tAgenA==",
       "requires": {
         "@types/glob": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/tunnel": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -56,6 +243,11 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
       "version": "0.19.2",
@@ -106,6 +298,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -124,10 +324,20 @@
         "ms": "2.0.0"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
+    "events": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -135,6 +345,16 @@
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
+      }
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -184,6 +404,19 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -196,6 +429,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "once": {
       "version": "1.4.0",
@@ -215,6 +453,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -230,6 +483,11 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "shelljs": {
       "version": "0.8.3",
@@ -263,6 +521,16 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
     "ts-node": {
       "version": "8.6.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
@@ -275,15 +543,49 @@
         "yn": "3.1.1"
       }
     },
+    "tslib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "yn": {
       "version": "3.1.1",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -179,6 +179,12 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/crypto-js": {
+      "version": "3.1.47",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-3.1.47.tgz",
+      "integrity": "sha512-eI6gvpcGHLk3dAuHYnRCAjX+41gMv1nz/VP55wAe5HtmAKDOoPSfr3f6vkMc08ov1S0NsjvUBxDtHHxqQY1LGA==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -315,6 +321,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "debug": {
       "version": "3.1.0",

--- a/test/package.json
+++ b/test/package.json
@@ -4,9 +4,12 @@
   "license": "MIT",
   "scripts": {
     "test": "npm install && node_modules/.bin/ts-node index.ts",
-    "test-win": "ts-node index.ts"
+    "test-win": "ts-node index.ts",
+    "test-kudulite": "npm install && node_modules/.bin/ts-node kudulite",
+    "test-kudulite-win": "ts-node kudulite"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.2.0-preview.1",
     "@types/shelljs": "^0.8.6",
     "axios": "^0.19.2",
     "chalk": "^3.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,12 +10,16 @@
   },
   "dependencies": {
     "@azure/storage-blob": "^12.2.0-preview.1",
-    "@types/shelljs": "^0.8.6",
     "axios": "^0.19.2",
     "chalk": "^3.0.0",
     "commander": "^4.1.1",
+    "crypto-js": "^4.0.0",
     "shelljs": "^0.8.3",
     "ts-node": "^8.6.2",
     "typescript": "^3.8.3"
+  },
+  "devDependencies": {
+    "@types/shelljs": "^0.8.6",
+    "@types/crypto-js": "^3.1.47"
   }
 }


### PR DESCRIPTION
### Background
Everytime when we release a new kudulite image, it takes quite a long time for the OGF to finish. We want to automate this process.

### Project Structure
**containers.ts** The main component of this system. It in charge of creating new kudulite container on local machine (build agent),  configure the kudulite container, orchestrate a remote build. Also, it validates if the built artifact can be run on those runtime images (e.g. mcr.microsoft.com/azure-functions/python:3.0-python3.6-appservice).
**testcases.ts** The place where we define testing different remote build scenarios.
**utils.ts** The sleeper and retrier.

### Flow
1. We upload the source project zip file (e.g. python36_src.zip) to source container
2. The program will first initialize a KuduLite container for remote build service
    1. setting up environment variables
    2. specialize the KuduLite container with POST /admin/instance/assign
3. The program will download the source project and do a local POST /api/zipdeploy request to the kudulite container
4. The built artifact will be uploaded onto a destination container
5. The test will generate a test image based on a runtime image
    1. specialize the runtime container with POST /admin/instance/assign
    2. download the artifact from WEBSITE_RUN_FROM_PACKAGE
    3. extract the artifact into /home/site/wwwroot
6. The test will check if the GET /api/HttpTrigger endpoint returns 200