### PR TITLE
Mitigate reference error in dotnet 2.2

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH=$PATH:/root/.dotnet/tools
 RUN cd /tmp \
     && git clone --depth 1 --branch $BRANCH https://github.com/$NAMESPACE/KuduLite.git KuduLite \
     && cd ./KuduLite/Kudu.Services.Web \
-    && benv dotnet=2.2 dotnet publish -c Release -o /opt/Kudu \
+    && benv dotnet=2.2.7 dotnet publish -c Release -o /opt/Kudu \
     && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \
     && rm -rf /tmp/* \
     && chmod a+rw /var/nuget \
@@ -65,12 +65,14 @@ ENV PATH=$PATH:/opt/nodejs/9/bin
 # Use Dynamic Install SDK feature from Oryx build
 # Trim off all unnecessary SDKs and let them lazily loaded
 RUN rm -rf /opt/python /opt/hugo /opt/php /opt/php-composer \
-    # We still need the fundamental ones when building the images nodejs 9, npm 6 and dotnet 2.2
-    # TODO: This will be upgraded to dotnet 3.1 soon
+    # We still need the fundamental ones when building the images nodejs 9, npm 6 and dotnet
     && find /opt/nodejs -mindepth 1 -maxdepth 1 -type d,l -not -name "9*" | xargs rm -rf \
-    && find /opt/npm -mindepth 1 -maxdepth 1 -type d,l -not -name "6*" | xargs rm -rf \
-    && find /opt/dotnet/runtimes -mindepth 1 -maxdepth 1 -type d,l -not -name '2*' | xargs rm -rf \
-    && find /opt/dotnet/sdks -mindepth 1 -maxdepth 1 -type d,l -not -name '2*' | xargs rm -rf
+    && find /opt/npm -mindepth 1 -maxdepth 1 -type d,l -not -name "6*" | xargs rm -rf
+
+# There's an exising bug in dotnet version detector in oryx image where it will resolve dotnet 2.2 into 2.2.8
+# But the image fails to resolve 2.2.8 runtime
+RUN ln -s /opt/dotnet/runtimes/2.2.7 /opt/dotnet/runtimes/2.2.8
+
 ENV ENABLE_DYNAMIC_INSTALL=true
 
 EXPOSE 80

--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -70,7 +70,7 @@ RUN rm -rf /opt/python /opt/hugo /opt/php /opt/php-composer \
     && find /opt/npm -mindepth 1 -maxdepth 1 -type d,l -not -name "6*" | xargs rm -rf
 
 # There's an exising bug in dotnet version detector in oryx image where it will resolve dotnet 2.2 into 2.2.8
-# But the image fails to resolve 2.2.8 runtime
+# But the image fails to resolve 2.2.8 runtime, thus, adding a symbolic link as temporary mitigation
 RUN ln -s /opt/dotnet/runtimes/2.2.7 /opt/dotnet/runtimes/2.2.8
 
 ENV ENABLE_DYNAMIC_INSTALL=true

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -51,4 +51,4 @@ cd /opt/Kudu
 
 echo $(date) running .net core
 # TODO: This will be updated to dotnet 3.1 soon
-ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2 dotnet Kudu.Services.Web.dll
+ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2.7 dotnet Kudu.Services.Web.dll

--- a/test/kudulite/containers.ts
+++ b/test/kudulite/containers.ts
@@ -263,13 +263,22 @@ export class KuduContainer {
         console.log(chalk.red.bold(`Failed to kill runtime container ${destContainerName}`));
       }
 
-      // Clean up docker image
-      console.log(chalk.yellow(`Cleaning up image ${baseImage}...`));
-      const rmiCommand = `docker rmi -f ${baseImage}`;
-      const rmiResult = shell.exec(rmiCommand);
-      if (rmiResult.code !== 0) {
-        console.log(chalk.red.bold(`Failed to remove runtime image ${baseImage}`));
+      // Clean up docker image ends with -python* -node* -java*
+      const isGenericImage = (
+        baseImage.endsWith(this.config.v2RuntimeVersion) || baseImage.endsWith(this.config.v3RuntimeVersion)
+      );
+      if (!isGenericImage) {
+        console.log(chalk.yellow(`Cleaning up image ${baseImage}...`));
+        const rmiCommand = `docker rmi -f ${baseImage}`;
+        const rmiResult = shell.exec(rmiCommand);
+        if (rmiResult.code !== 0) {
+          console.log(chalk.red.bold(`Failed to remove runtime image ${baseImage}`));
+        }
+      } else {
+        console.log(chalk.yellow(`Retained generatic image ${baseImage}.`));
       }
+
+      // Remove ports registry
       delete KuduContainer.ports[destContainerName];
     }
 

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -9,7 +9,12 @@ import {
   Host20Node8,
   Host20Node10,
   Host30Node10,
-  Host30Node12
+  Host30Node12,
+  Host20Dotnet2,
+  Host30Dotnet3,
+  Host2xPython36CsprojExtensions,
+  Host3xPython36CsprojExtensions,
+  Host30Python36OverwriteRunFromPackage
 } from './testcases'
 
 // Flow
@@ -71,6 +76,10 @@ async function initialize(): Promise<IConfig> {
 async function main() {
   const config: IConfig = await initialize();
 
+  // Dotnet
+  const testHost20Dotnet2 = new Host20Dotnet2();
+  const testHost30Dotnet3 = new Host30Dotnet3();
+
   // Python
   const testHost20Python36 = new Host20Python36();
   const testHost20Python37 = new Host20Python37();
@@ -84,8 +93,19 @@ async function main() {
   const testHost30Node10 = new Host30Node10();
   const testHost30Node12 = new Host30Node12();
 
+  // Special Cases
+  const testOverwriteAppSetting = new Host30Python36OverwriteRunFromPackage();
+  const testHost20Python36Extensions = new Host2xPython36CsprojExtensions();
+  const testHost21Python36Extensions = new Host2xPython36CsprojExtensions();
+  const testHost22Python36Extensions = new Host2xPython36CsprojExtensions();
+  const testHost30Python36Extensions = new Host3xPython36CsprojExtensions();
+
   try {
     // CI disk space limitation hit, fail to run all tests parallelly.
+
+    await testHost20Dotnet2.run(config, 'KuduLiteDotnet2.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
+    await testHost30Dotnet3.run(config, 'KuduLiteDotnet3.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+
     await testHost20Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
     await testHost20Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}-python3.7`);
     await testHost20Node8.run(config, 'KuduLiteNode8.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
@@ -95,6 +115,13 @@ async function main() {
     await testHost30Python38.run(config, 'KuduLitePython38.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`);
     await testHost30Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
     await testHost30Node12.run(config, 'KuduLiteNode12.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-node12`);
+
+    await testOverwriteAppSetting.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+    await testHost20Python36Extensions.run(config, 'KuduLitePython36Extension20.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
+    await testHost21Python36Extensions.run(config, 'KuduLitePython36Extension21.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
+    await testHost22Python36Extensions.run(config, 'KuduLitePython36Extension22.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v2RuntimeVersion}`);
+    await testHost30Python36Extensions.run(config, 'KuduLitePython36Extension30.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+
   } catch (error) {
     console.log(chalk.red.bold(error));
     process.exit(1)

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -1,6 +1,56 @@
 import { ITestCase, IConfig } from "./interfaces";
 import { KuduContainer } from "./containers";
 
+// Host 2.0 Dotnet2 /api/zipdeploy
+export class Host20Dotnet2 implements ITestCase {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
+    const settings = {
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
+      "FUNCTIONS_EXTENSION_VERSION": "~2",
+      "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+      "FRAMEWORK": "dotnet",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "2",
+      "FRAMEWORK_VERSION": "2",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact(runtimeImage, settings);
+    container.killContainer();
+  }
+}
+
+// Host 3.0 Dotnet3 /api/zipdeploy
+export class Host30Dotnet3 implements ITestCase {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
+    const settings = {
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+      "FRAMEWORK": "dotnet",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3",
+      "FRAMEWORK_VERSION": "3",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact(runtimeImage, settings);
+    container.killContainer();
+  }
+}
+
 // Host 2.0 Python36 /api/zipdeploy
 export class Host20Python36 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
@@ -51,7 +101,7 @@ export class Host20Python37 implements ITestCase {
   }
 }
 
-// Host 3.0 Python36 /api/zipdeploy?overwriteWebsiteRunFromPackage=true
+// Host 3.0 Python36 /api/zipdeploy
 export class Host30Python36 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -76,6 +126,7 @@ export class Host30Python36 implements ITestCase {
   }
 }
 
+// Host 3.0 Python37 /api/zipdeploy
 export class Host30Python37 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -100,6 +151,7 @@ export class Host30Python37 implements ITestCase {
   }
 }
 
+// Host 3.0 Python38 /api/zipdeploy
 export class Host30Python38 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -124,6 +176,7 @@ export class Host30Python38 implements ITestCase {
   }
 }
 
+// Host 2.0 Node8 /api/zipdeploy
 export class Host20Node8 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -148,6 +201,7 @@ export class Host20Node8 implements ITestCase {
   }
 }
 
+// Host 2.0 Node10 /api/zipdeploy
 export class Host20Node10 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -172,6 +226,7 @@ export class Host20Node10 implements ITestCase {
   }
 }
 
+// Host 3.0 Node10 /api/zipdeploy
 export class Host30Node10 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -196,6 +251,7 @@ export class Host30Node10 implements ITestCase {
   }
 }
 
+// Host 3.0 Node12 /api/zipdeploy
 export class Host30Node12 implements ITestCase {
   public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
     const container = new KuduContainer(config);
@@ -209,6 +265,86 @@ export class Host30Node12 implements ITestCase {
       "FRAMEWORK": "node",
       "FUNCTIONS_WORKER_RUNTIME_VERSION": "12",
       "FRAMEWORK_VERSION": "12",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact(runtimeImage, settings);
+    container.killContainer();
+  }
+}
+
+// Host 3.0 Python36 /api/zipdeploy?overwriteWebsiteRunFromPackage=true
+export class Host30Python36OverwriteRunFromPackage implements ITestCase {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
+    const settings = {
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
+      "FRAMEWORK_VERSION": "3.6",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
+    await container.createZipDeploy(localSrcPath, {
+      overwriteWebsiteRunFromPackage: 'true'
+    });
+    await container.testBuiltArtifact(runtimeImage, settings);
+    container.killContainer();
+  }
+}
+
+// Host 2.x Python36 /api/zipdeploy with extensions.csproj
+// For testing function app without extension bundle
+export class Host2xPython36CsprojExtensions implements ITestCase {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
+    const settings = {
+      "AzureWebJobsStorage": config.storageConnectionString,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
+      "FUNCTIONS_EXTENSION_VERSION": "~2",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
+      "FRAMEWORK_VERSION": "3.6",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact(runtimeImage, settings);
+    container.killContainer();
+  }
+}
+
+// Host 3.0 Python36 /api/zipdeploy with extensions.csproj
+export class Host3xPython36CsprojExtensions implements ITestCase {
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
+    const settings = {
+      "AzureWebJobsStorage": config.storageConnectionString,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
+      "FRAMEWORK_VERSION": "3.6",
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -282,6 +282,7 @@ export class Host30Python36OverwriteRunFromPackage implements ITestCase {
     const container = new KuduContainer(config);
     const destSas = await container.getDestBlobSas();
     const settings = {
+      "AzureWebJobsStorage": config.storageConnectionString,
       "ENABLE_ORYX_BUILD": 'true',
       "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
       "ENABLE_DYNAMIC_INSTALL": 'true',
@@ -290,7 +291,7 @@ export class Host30Python36OverwriteRunFromPackage implements ITestCase {
       "FRAMEWORK": "python",
       "FUNCTIONS_WORKER_RUNTIME_VERSION": "3.6",
       "FRAMEWORK_VERSION": "3.6",
-      "SCM_RUN_FROM_PACKAGE": destSas
+      "WEBSITE_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);
     const localSrcPath = await container.downloadSrcBlob(srcPackage);


### PR DESCRIPTION
**Background:**
The kudu-2.12 image has an issue due to Oryx Build fails to resolve netcoreapp2.2 extensions a proper sdk.
Netcoreapp2.2 will always point to 2.2.8 runtime (sdk 2.2.207) where the SDK version is older then 2.2.7 runtime (sdk 2.2.402).
This conflict yields to an issue when resolving the extensions.csproj in remote build.

**Mitigation:**
Still waiting for the fix on Oryx Build side. To mitigate, I made a symbolic link points 2.2.8 to 2.2.7 runtime.

**Micellaneous:**
Added a few more test cases for
1. dotnet 2.x and  dotnet 3.x
2. python with dotnet extensions
3. overwrite WEBSITE_RUN_FROM_PACKAGE app setting in api/zipdeploy endpoint