### PR TITLE
Fix Python library (-lpython3xm.so) link failure in remote build

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -3,7 +3,7 @@ COPY /mesh /mesh
 RUN cd /mesh && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o init
 
-FROM mcr.microsoft.com/oryx/build:20200813.1 as pre-final-env
+FROM mcr.microsoft.com/oryx/build:20200929.1 as pre-final-env
 ARG BRANCH
 ARG NAMESPACE
 ENV DEBIAN_FRONTEND noninteractive
@@ -43,11 +43,11 @@ ENV NUGET_XMLDOC_MODE=skip
 RUN dotnet tool install -g dotnet-aspnet-codegenerator --version 2.2.4
 ENV PATH=$PATH:/root/.dotnet/tools
 
-# Install Kudu
+# Install Kudu (since oryx/build:20200929.1, benv dotnet only accept full version)
 RUN cd /tmp \
     && git clone --depth 1 --branch $BRANCH https://github.com/$NAMESPACE/KuduLite.git KuduLite \
     && cd ./KuduLite/Kudu.Services.Web \
-    && benv dotnet=2.2.7 dotnet publish -c Release -o /opt/Kudu \
+    && benv dotnet=2.2.207 dotnet publish -c Release -o /opt/Kudu \
     && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \
     && rm -rf /tmp/* \
     && chmod a+rw /var/nuget \
@@ -57,21 +57,15 @@ COPY startup.sh /
 
 RUN chmod 777 /startup.sh
 
-RUN benv node=9 npm=6 npm install -g kudusync pm2@latest
+RUN benv node=9 npm install -g kudusync pm2@latest
 
 RUN ln -s /opt/nodejs/9/lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm-cli.js
 ENV PATH=$PATH:/opt/nodejs/9/bin
 
 # Use Dynamic Install SDK feature from Oryx build
-# Trim off all unnecessary SDKs and let them lazily loaded
-RUN rm -rf /opt/python /opt/hugo /opt/php /opt/php-composer \
-    # We still need the fundamental ones when building the images nodejs 9, npm 6 and dotnet
-    && find /opt/nodejs -mindepth 1 -maxdepth 1 -type d,l -not -name "9*" | xargs rm -rf \
-    && find /opt/npm -mindepth 1 -maxdepth 1 -type d,l -not -name "6*" | xargs rm -rf
-
-# There's an exising bug in dotnet version detector in oryx image where it will resolve dotnet 2.2 into 2.2.8
-# But the image fails to resolve 2.2.8 runtime, thus, adding a symbolic link as temporary mitigation
-RUN ln -s /opt/dotnet/runtimes/2.2.7 /opt/dotnet/runtimes/2.2.8
+RUN rm -rf /opt/python /opt/hugo /opt/php /opt/php-composer /opt/npm \
+    # We still need the fundamental ones when building the images nodejs 9 and dotnet
+    && find /opt/nodejs -mindepth 1 -maxdepth 1 -type d,l -not -name "9*" | xargs rm -rf
 
 ENV ENABLE_DYNAMIC_INSTALL=true
 

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -51,4 +51,4 @@ cd /opt/Kudu
 
 echo $(date) running .net core
 # TODO: This will be updated to dotnet 3.1 soon
-ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2.7 dotnet Kudu.Services.Web.dll
+ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2.207 dotnet Kudu.Services.Web.dll

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -117,8 +117,8 @@ async function main() {
     await testHost30Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
     await testHost30Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`);
     await testHost30Python38.run(config, 'KuduLitePython38.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`);
-    await testPython37BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`);
     await testPython36BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+    await testPython37BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`);
     await testPython38BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`);
 
     await testHost30Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);

--- a/test/kudulite/index.ts
+++ b/test/kudulite/index.ts
@@ -14,7 +14,8 @@ import {
   Host30Dotnet3,
   Host2xPython36CsprojExtensions,
   Host3xPython36CsprojExtensions,
-  Host30Python36OverwriteRunFromPackage
+  Host30Python36OverwriteRunFromPackage,
+  Host3xPython3xBuildWheel
 } from './testcases'
 
 // Flow
@@ -84,8 +85,11 @@ async function main() {
   const testHost20Python36 = new Host20Python36();
   const testHost20Python37 = new Host20Python37();
   const testHost30Python36 = new Host30Python36();
+  const testPython36BuildWheel = new Host3xPython3xBuildWheel('3.6');
   const testHost30Python37 = new Host30Python37();
+  const testPython37BuildWheel = new Host3xPython3xBuildWheel('3.7');
   const testHost30Python38 = new Host30Python38();
+  const testPython38BuildWheel = new Host3xPython3xBuildWheel('3.8');
 
   // Node
   const testHost20Node8 = new Host20Node8();
@@ -113,6 +117,10 @@ async function main() {
     await testHost30Python36.run(config, 'KuduLitePython36.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
     await testHost30Python37.run(config, 'KuduLitePython37.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`);
     await testHost30Python38.run(config, 'KuduLitePython38.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`);
+    await testPython37BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.7`);
+    await testPython36BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
+    await testPython38BuildWheel.run(config, 'KuduLitePythonBuildWheel.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-python3.8`);
+
     await testHost30Node10.run(config, 'KuduLiteNode10.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}`);
     await testHost30Node12.run(config, 'KuduLiteNode12.zip', `mcr.microsoft.com/azure-functions/mesh:${config.v3RuntimeVersion}-node12`);
 

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -356,3 +356,31 @@ export class Host3xPython36CsprojExtensions implements ITestCase {
     container.killContainer();
   }
 }
+
+// Host 3.0 Python3x /api/zipdeploy with pyodbc, need to build wheel
+export class Host3xPython3xBuildWheel implements ITestCase {
+  public constructor(private pythonVersion: string) {}
+
+  public async run(config: IConfig, srcPackage: string, runtimeImage: string): Promise<void> {
+    const container = new KuduContainer(config);
+    const destSas = await container.getDestBlobSas();
+    const settings = {
+      "AzureWebJobsStorage": config.storageConnectionString,
+      "ENABLE_ORYX_BUILD": 'true',
+      "SCM_DO_BUILD_DURING_DEPLOYMENT": 'true',
+      "ENABLE_DYNAMIC_INSTALL": 'true',
+      "FUNCTIONS_EXTENSION_VERSION": "~3",
+      "FUNCTIONS_WORKER_RUNTIME": "python",
+      "FRAMEWORK": "python",
+      "FUNCTIONS_WORKER_RUNTIME_VERSION": this.pythonVersion,
+      "FRAMEWORK_VERSION": "3.6",
+      "SCM_RUN_FROM_PACKAGE": destSas
+    }
+    const kuduliteContainerName = await container.startKuduLiteContainer(settings);
+    const localSrcPath = await container.downloadSrcBlob(srcPackage);
+    await container.assignContainer(kuduliteContainerName, settings);
+    await container.createZipDeploy(localSrcPath);
+    await container.testBuiltArtifact(runtimeImage, settings);
+    container.killContainer();
+  }
+}

--- a/test/kudulite/testcases.ts
+++ b/test/kudulite/testcases.ts
@@ -373,7 +373,7 @@ export class Host3xPython3xBuildWheel implements ITestCase {
       "FUNCTIONS_WORKER_RUNTIME": "python",
       "FRAMEWORK": "python",
       "FUNCTIONS_WORKER_RUNTIME_VERSION": this.pythonVersion,
-      "FRAMEWORK_VERSION": "3.6",
+      "FRAMEWORK_VERSION": this.pythonVersion,
       "SCM_RUN_FROM_PACKAGE": destSas
     }
     const kuduliteContainerName = await container.startKuduLiteContainer(settings);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-core-tools/issues/2243

This is an issue in the old oryx image mcr.microsoft.com/oryx/build:20200813.1.
Thanks for the help @kichalla as we discussed offline, the new image addresses a few issue:
1. dotnet runtime 2.2.8 and sdk 2.2.207 are now available in the remote build, no longer need the symbolic link to make it work
`RUN ln -s /opt/dotnet/runtimes/2.2.7 /opt/dotnet/runtimes/2.2.8`.
2. npm comes with nodejs, we can trim off npm folder completely to further reduce image size.
3. Python library linking issue (e.g. -lpython3.6m) is fixed.

Added a new test scenario for resolving **pyodbc** Python module.
https://kuduliteimagetest.blob.core.windows.net/testsrc/KuduLitePythonBuildWheel.zip?sv=2019-02-02&st=2020-09-29T23%3A47%3A37Z&se=2024-09-30T23%3A47%3A00Z&sr=b&sp=r&sig=A5OK6ZAIEPcz8v0UqkaigBPhWYdRM42nH29ghYWsQ48%3D