### PR TITLE
updating to 2.0.14786 and 3.0.14785

### DIFF
--- a/host/2.0/alpine/amd64/dotnet/dotnet.Dockerfile
+++ b/host/2.0/alpine/amd64/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/alpine/amd64/dotnet/dotnet.Dockerfile
+++ b/host/2.0/alpine/amd64/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/alpine/amd64/java/java8.Dockerfile
+++ b/host/2.0/alpine/amd64/java/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/alpine/amd64/java/java8.Dockerfile
+++ b/host/2.0/alpine/amd64/java/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/alpine/amd64/powershell/powershell6.Dockerfile
+++ b/host/2.0/alpine/amd64/powershell/powershell6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/alpine/amd64/powershell/powershell6.Dockerfile
+++ b/host/2.0/alpine/amd64/powershell/powershell6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/2.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION

--- a/host/2.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/2.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION

--- a/host/2.0/nanoserver/1803/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1803/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=2.0.14494
+    HOST_VERSION=2.0.14778
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/2.0/nanoserver/1803/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1803/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=2.0.14778
+    HOST_VERSION=2.0.14786
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/2.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1809/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=2.0.14494
+    HOST_VERSION=2.0.14778
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/2.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1809/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=2.0.14778
+    HOST_VERSION=2.0.14786
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/2.0/nanoserver/1903/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1903/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=2.0.14494
+    HOST_VERSION=2.0.14778
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/2.0/nanoserver/1903/dotnet.Dockerfile
+++ b/host/2.0/nanoserver/1903/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=2.0.14778
+    HOST_VERSION=2.0.14786
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/2.0/stretch/amd64/dotnet/dotnet-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/dotnet/dotnet-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/dotnet/dotnet-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/dotnet/dotnet-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/dotnet/dotnet.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/dotnet/dotnet.Dockerfile
+++ b/host/2.0/stretch/amd64/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/java/java8-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8-appservice.Dockerfile
@@ -4,7 +4,7 @@
 # and are not intended to be used for any other purpose.
 
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/java/java8-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8-appservice.Dockerfile
@@ -4,7 +4,7 @@
 # and are not intended to be used for any other purpose.
 
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/java/java8-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/java/java8-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/java/java8.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/java/java8.Dockerfile
+++ b/host/2.0/stretch/amd64/java/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node10/node10-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node10/node10-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node10/node10.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node10/node10.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node10/node10.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node12/node12-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node12/node12-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node12/node12.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node12/node12.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node12/node12.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node8/node8-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node8/node8-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node8/node8-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node8/node8-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node8/node8.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/node/node8/node8.Dockerfile
+++ b/host/2.0/stretch/amd64/node/node8/node8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/powershell/powershell6-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/powershell/powershell6-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/powershell/powershell6-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/powershell/powershell6-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/powershell/powershell6-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/powershell/powershell6-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/powershell/powershell6-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/powershell/powershell6-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/powershell/powershell6.Dockerfile
+++ b/host/2.0/stretch/amd64/powershell/powershell6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/powershell/powershell6.Dockerfile
+++ b/host/2.0/stretch/amd64/powershell/powershell6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python36/python36-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36/python36-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/2.0/stretch/amd64/python/python36/python36-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36/python36-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/2.0/stretch/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36/python36-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36/python36-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python36/python36.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36/python36.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python36/python36.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python36/python36.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python37/python37-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37/python37-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python37/python37-appservice.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37/python37-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37/python37-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37/python37-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python37/python37.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37/python37.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/amd64/python/python37/python37.Dockerfile
+++ b/host/2.0/stretch/amd64/python/python37/python37.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/2.0/stretch/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/2.0/stretch/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14494
+ARG HOST_VERSION=2.0.14778
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION

--- a/host/2.0/stretch/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/2.0/stretch/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=2.0.14778
+ARG HOST_VERSION=2.0.14786
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS runtime-image
 ARG HOST_VERSION

--- a/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION

--- a/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION

--- a/host/3.0/buster/amd64/dotnet/dotnet-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java11/java11-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java11/java11-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java8/java8-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java8/java8-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node10/node10-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node10/node10-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node12/node12-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node12/node12-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/powershell/powershell6-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/powershell/powershell6-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/powershell/powershell6-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/powershell/powershell6-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/powershell/powershell6.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/powershell/powershell6.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python36/python36-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python36/python36-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python37/python37-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python37/python37-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python38/python38-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python38/python38-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14492
+ARG HOST_VERSION=3.0.14777
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION

--- a/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=3.0.14777
+ARG HOST_VERSION=3.0.14785
 FROM mcr.microsoft.com/azure-functions/base:grpc-2.27-arm32v7 as grpc-image
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS runtime-image
 ARG HOST_VERSION

--- a/host/3.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1809/dotnet.Dockerfile
@@ -22,7 +22,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=3.0.14492
+    HOST_VERSION=3.0.14777
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/3.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1809/dotnet.Dockerfile
@@ -22,7 +22,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=3.0.14777
+    HOST_VERSION=3.0.14785
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/3.0/nanoserver/1903/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1903/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=3.0.14777
+    HOST_VERSION=3.0.14785
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/3.0/nanoserver/1903/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1903/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=3.0.14492
+    HOST_VERSION=3.0.14777
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/3.0/nanoserver/1909/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1909/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=3.0.14777
+    HOST_VERSION=3.0.14785
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `

--- a/host/3.0/nanoserver/1909/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1909/dotnet.Dockerfile
@@ -23,7 +23,7 @@ ENV ASPNETCORE_URLS=http://+:80 `
     DOTNET_USE_POLLING_FILE_WATCHER=true `
     NUGET_XMLDOC_MODE=skip `
     PublishWithAspNetCoreTargetManifest=false `
-    HOST_VERSION=3.0.14492
+    HOST_VERSION=3.0.14777
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
     $BuildNumber = $Env:HOST_VERSION.split('.')[-1]; `


### PR DESCRIPTION
Adding links to the release pages of the versions being updated
[v3.0.14785](https://github.com/Azure/azure-functions-host/releases/tag/v3.0.14785)
[v2.0.14786](https://github.com/Azure/azure-functions-host/releases/tag/v2.0.14786)