### PR TITLE
Remove dotnet isolated test from mesh

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,12 @@ if (process.argv.length < 2) {
 const storagePath =
   "https://functionsdockertests.blob.core.windows.net/public/docker";
 
+const dotnetIsolated = {
+  package: `${storagePath}/dotnet-isolated-functions.zip`,
+  invoke: "/api/DotnetIsolatedHttpFunction",
+  response: "Hello, Test"
+}
+
 const map = {
   python: {
     package: `${storagePath}/python-functions.zip`,
@@ -32,11 +38,6 @@ const map = {
     invoke: "/api/CSharpHttpFunction?name=Test",
     response: "Hello, Test"
   },
-  dotnetIsolated: {
-    package: `${storagePath}/dotnet-isolated-functions.zip`,
-    invoke: "/api/DotnetIsolatedHttpFunction",
-    response: "Hello, Test"
-  },
   java: {
     package: `${storagePath}/java-functions.zip`,
     invoke: "/api/HttpTrigger-Java?name=Test",
@@ -51,7 +52,7 @@ const testData = (function() {
   else if (imageName.indexOf("powershell") !== -1) return map.powershell;
   else if (imageName.indexOf("python") !== -1) return map.python;
   else if (imageName.indexOf("node") !== -1) return map.node;
-  else if (imageName.indexOf("dotnet-isolated") !== -1) return map.dotnetIsolated;
+  else if (imageName.indexOf("dotnet-isolated") !== -1) return dotnetIsolated;
   else if (imageName.indexOf("mesh") !== -1) return map;
   else return map.dotnet;
 })();
@@ -184,7 +185,6 @@ async function main() {
     await runTest(testData);
   } else {
     await runTest(testData.dotnet, "-e FUNCTIONS_WORKER_RUNTIME=dotnet");
-    await runTest(testData.dotnetIsolated, "-e FUNCTIONS_WORKER_RUNTIME=dotnet-isolated");
     await runTest(testData.node, "-e FUNCTIONS_WORKER_RUNTIME=node");
     await runTest(testData.python, "-e FUNCTIONS_WORKER_RUNTIME=python");
     await runTest(testData.java, "-e FUNCTIONS_WORKER_RUNTIME=java");


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

I had added `dotnet-isolated` test as part of my dotnet 5 PR. However, mesh  images run all tests in  `map`. Mesh doesn't support .NET 5 yet. So for now, I have moved the .NET 5 test out of the map. Once we have added mesh support, I will move it back how I had initially added it.

This will unblock mesh build test failure.

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
