### PR TITLE
Fix the issue of dotnet-isolated:3.0.15417-dotnet-isolated5.0-appservice not found

### DIFF
--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -97,7 +97,7 @@ steps:
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/dotnet:$(Build.SourceBranchName)-dotnet-isolated5.0-appservice
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/dotnet-isolated:$(Build.SourceBranchName)-dotnet-isolated5.0-appservice
 
       docker build -t $IMAGE_NAME \
                   -f host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile \


### PR DESCRIPTION
Potential Fix : https://github.com/Azure/azure-functions-docker/issues/395

Failed Pipeline 
https://azure-functions.visualstudio.com/azure-functions-docker/_build/results?buildId=8035&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=356bb04c-cb4a-5f04-82ca-d3b102917eba

Error message: 

```
Error response from daemon: manifest for azurefunctions.azurecr.io/azure-functions/3.0/dotnet-isolated:3.0.15417-dotnet-isolated5.0-appservice not found: manifest unknown: manifest tagged by "3.0.15417-dotnet-isolated5.0-appservice" is not found
```

Hi @ankitkumarr Could you review it please?


