### PR TITLE
Adding dotnet isolated image to the core-tools nightly build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Linux amd64 Tags
 
 | Tags                                       | Dockerfile                                                              | OS Version |
 |--------------------------------------------|-------------------------------------------------------------------------|------------|
-| `3.0`                                      | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet.Dockerfile)            | Debian 10  |
+| `3.0`                                      | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile)            | Debian 10  |
 | `3.0-dotnet-isolated5.0-slim`                                 | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-slim.Dockerfile)       | Debian 10  |
 | `3.0-appservice`, `3.0-dotnet-isolated5.0-appservice` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-appservice.Dockerfile) | Debian 10  |
-| `3.0-dotnet-isolated5.0-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-core-tools.Dockerfile) | Debian 10  |
+| `3.0-dotnet-isolated5.0-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/-isolated-core-tools.Dockerfile) | Debian 10  |
 
 Linux arm32v7 Tags
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Linux amd64 Tags
 | Tags                                       | Dockerfile                                                              | OS Version |
 |--------------------------------------------|-------------------------------------------------------------------------|------------|
 | `3.0`                                      | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile)            | Debian 10  |
-| `3.0-dotnet-isolated5.0-slim`                                 | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-slim.Dockerfile)       | Debian 10  |
-| `3.0-appservice`, `3.0-dotnet-isolated5.0-appservice` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-appservice.Dockerfile) | Debian 10  |
-| `3.0-dotnet-isolated5.0-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/-isolated-core-tools.Dockerfile) | Debian 10  |
+| `3.0-dotnet-isolated5.0-slim`                                 | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile)       | Debian 10  |
+| `3.0-appservice`, `3.0-dotnet-isolated5.0-appservice` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile) | Debian 10  |
+| `3.0-dotnet-isolated5.0-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile) | Debian 10  |
 
 Linux arm32v7 Tags
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,20 @@ Linux amd64 Tags
 
 | Tags                                       | Dockerfile                                                              | OS Version |
 |--------------------------------------------|-------------------------------------------------------------------------|------------|
-| `3.0`                                      | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet.Dockerfile)            | Debian 10  |
-| `3.0-slim`                                 | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-slim.Dockerfile)       | Debian 10  |
-| `3.0-appservice`, `3.0-dotnet3-appservice` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-appservice.Dockerfile) | Debian 10  |
-| `3.0-dotnet3-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile) | Debian 10  |
+| `3.0`                                      | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile)            | Debian 10  |
+| `3.0-slim`                                 | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile)       | Debian 10  |
+| `3.0-appservice`, `3.0-dotnet3-appservice` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-appservice.Dockerfile) | Debian 10  |
+| `3.0-dotnet3-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile) | Debian 10  |
+
+
+`mcr.microsoft.com/azure-functions/dotnet-isolated`
+
+| Tags                                       | Dockerfile                                                              | OS Version |
+|--------------------------------------------|-------------------------------------------------------------------------|------------|
+| `3.0`                                      | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet.Dockerfile)            | Debian 10  |
+| `3.0-dotnet-isolated5.0-slim`                                 | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-slim.Dockerfile)       | Debian 10  |
+| `3.0-appservice`, `3.0-dotnet-isolated5.0-appservice` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-appservice.Dockerfile) | Debian 10  |
+| `3.0-dotnet-isolated5.0-core-tools` | [Dockerfile](host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-core-tools.Dockerfile) | Debian 10  |
 
 Linux arm32v7 Tags
 

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -421,8 +421,8 @@ stages:
           set -e
           docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools
 
-          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet-isolated5.0-core-tools
-          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools  
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-core-tools
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet-isolated5.0-core-tools  
           
         displayName: tag dotnet isolated images
         continueOnError: false

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -63,11 +63,53 @@ stages:
           IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/dotnet:$(PrivateVersion)-dotnet3-core-tools
     
           docker build -t $IMAGE_NAME \
-                      -f host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile \
+                      -f host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile \
                       host/3.0/buster/amd64/dotnet/
           npm run test $IMAGE_NAME --prefix  test/
           docker push $IMAGE_NAME
         displayName: dotnet-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1
+
+  - job: dotnet5isolated
+    displayName: DotNet 5 Isolated
+    steps: 
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          itemPattern: 
+          downloadPath: '$(System.ArtifactsDirectory)'
+      - bash: |
+          targetVersion=`cat $(System.ArtifactsDirectory)/drop/core-tools-version.txt`
+          privateVersion=${targetVersion}.`cat $(System.ArtifactsDirectory)/drop/week.txt`
+          echo "targetVersion: ${targetVersion}"
+          echo "##vso[task.setvariable variable=TargetVersion;]${targetVersion}"
+          echo "privateVersion: ${privateVersion}"
+          echo "##vso[task.setvariable variable=PrivateVersion;]${privateVersion}"
+        displayName: share the targetVersion and PrivateVersion
+      - bash: |
+          # login
+          set -e
+          echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+
+        displayName: login to registry
+        continueOnError: false
+        env:
+          pswd: $(dockerPassword)
+
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools
+    
+          docker build -t $IMAGE_NAME \
+                      -f host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/dotnet/
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: dotnet-core-tools isolated
         continueOnError: false
         env:
           DOCKER_BUILDKIT: 1
@@ -343,38 +385,72 @@ stages:
     
       - bash: |
           set -e
-          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools
+          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools
 
-          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
-          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
           
         displayName: tag dotnet images
         continueOnError: false
       - bash: |
           set -e 
-          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools --format='{{.Id}}'`
-          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools --format='{{.Id}}'`
           if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
             echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
             exit 1;
           fi
-          ActualVersion=`docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools func --version`
+          ActualVersion=`docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools func --version`
           if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
             echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
             exit 1; 
           fi
-          docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools az --version
+          docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools az --version
         displayName: test dotnet images
         continueOnError: false
       - bash: |
           set -e 
-          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
-          docker push $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools
+          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet-isolated5.0-core-tools
+          docker push $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools
           docker system prune -a -f
         displayName: push dotnet images
         continueOnError: false
         condition: ne(variables['SkipProduction'], 'true')
-        
+
+      - bash: |
+          set -e
+          docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools
+
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
+          
+        displayName: tag dotnet isolated images
+        continueOnError: false
+      - bash: |
+          set -e 
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+          ActualVersion=`docker run $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1; 
+          fi
+          docker run $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools az --version
+        displayName: test dotnet isolated images
+        continueOnError: false
+      - bash: |
+          set -e 
+          docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet3-core-tools
+          docker push $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools
+          docker system prune -a -f
+        displayName: push dotnet isolated images
+        continueOnError: false
+        condition: ne(variables['SkipProduction'], 'true')
+
       - bash: |
           set -e
           docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-core-tools

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -64,7 +64,7 @@ stages:
     
           docker build -t $IMAGE_NAME \
                       -f host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile \
-                      host/3.0/buster/amd64/dotnet/
+                      host/3.0/buster/amd64/dotnet/dotnet-inproc/
           npm run test $IMAGE_NAME --prefix  test/
           docker push $IMAGE_NAME
         displayName: dotnet-core-tools
@@ -106,7 +106,7 @@ stages:
     
           docker build -t $IMAGE_NAME \
                       -f host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile \
-                      host/3.0/buster/amd64/dotnet/
+                      host/3.0/buster/amd64/dotnet/dotnet-isolated/
           npm run test $IMAGE_NAME --prefix  test/
           docker push $IMAGE_NAME
         displayName: dotnet-core-tools isolated
@@ -385,33 +385,33 @@ stages:
     
       - bash: |
           set -e
-          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools
+          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools
 
-          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
-          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
           
         displayName: tag dotnet images
         continueOnError: false
       - bash: |
           set -e 
-          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet-isolated5.0-core-tools --format='{{.Id}}'`
-          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools --format='{{.Id}}'`
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools --format='{{.Id}}'`
           if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
             echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
             exit 1;
           fi
-          ActualVersion=`docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools func --version`
+          ActualVersion=`docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools func --version`
           if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
             echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
             exit 1; 
           fi
-          docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools az --version
+          docker run $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools az --version
         displayName: test dotnet images
         continueOnError: false
       - bash: |
           set -e 
-          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet-isolated5.0-core-tools
-          docker push $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools
+          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
+          docker push $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools
           docker system prune -a -f
         displayName: push dotnet images
         continueOnError: false
@@ -419,33 +419,33 @@ stages:
 
       - bash: |
           set -e
-          docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools
+          docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools
 
-          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet3-core-tools
-          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet3-core-tools  
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet-isolated5.0-core-tools
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools $TARGET_REGISTRY/dotnet:$(MajorVersion)-dotnet-isolated5.0-core-tools  
           
         displayName: tag dotnet isolated images
         continueOnError: false
       - bash: |
           set -e 
-          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet3-core-tools --format='{{.Id}}'`
-          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools --format='{{.Id}}'`
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet-isolated5.0-core-tools --format='{{.Id}}'`
           if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
             echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
             exit 1;
           fi
-          ActualVersion=`docker run $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools func --version`
+          ActualVersion=`docker run $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet-isolated5.0-core-tools func --version`
           if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
             echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
             exit 1; 
           fi
-          docker run $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools az --version
+          docker run $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet-isolated5.0-core-tools az --version
         displayName: test dotnet isolated images
         continueOnError: false
       - bash: |
           set -e 
-          docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet3-core-tools
-          docker push $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet3-core-tools
+          docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-core-tools
+          docker push $TARGET_REGISTRY/dotnet-isolated:$(MajorVersion)-dotnet-isolated5.0-core-tools
           docker system prune -a -f
         displayName: push dotnet isolated images
         continueOnError: false


### PR DESCRIPTION
Fix : https://github.com/Azure/azure-functions-docker/issues/394

Since the dotnet-isolated imaged is added, the directory structure has not been changed. 
This Pipeline also add the feature to publish the dotnet 5 isolated core tools images. 

@ankitkumarr Could you have a look?
