### PR TITLE
Update oryx build base image to buster

### DIFF
--- a/kudulite/Dockerfile
+++ b/kudulite/Dockerfile
@@ -3,7 +3,7 @@ COPY /mesh /mesh
 RUN cd /mesh && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o init
 
-FROM mcr.microsoft.com/oryx/build:20201015.1 as pre-final-env
+FROM mcr.microsoft.com/oryx/build:20210708.1 as pre-final-env
 ARG BRANCH
 ARG NAMESPACE
 ENV DEBIAN_FRONTEND noninteractive
@@ -47,7 +47,7 @@ ENV PATH=$PATH:/root/.dotnet/tools
 RUN cd /tmp \
     && git clone --depth 1 --branch $BRANCH https://github.com/$NAMESPACE/KuduLite.git KuduLite \
     && cd ./KuduLite/Kudu.Services.Web \
-    && benv dotnet=2.2.207 dotnet publish -c Release -o /opt/Kudu \
+    && benv dotnet=3.1.409 dotnet publish -c Release -o /opt/Kudu \
     && chmod 777 /opt/Kudu/Kudu.Services.Web.dll \
     && rm -rf /tmp/* \
     && chmod a+rw /var/nuget \

--- a/kudulite/startup.sh
+++ b/kudulite/startup.sh
@@ -51,4 +51,4 @@ cd /opt/Kudu
 
 echo $(date) running .net core
 # TODO: This will be updated to dotnet 3.1 soon
-ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=2.2.207 dotnet Kudu.Services.Web.dll
+ASPNETCORE_URLS=http://0.0.0.0:"$PORT" runuser -p -u "$USER_NAME" -- benv dotnet=3.1.409 dotnet Kudu.Services.Web.dll


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->


<!-- If you are doing releasing a new host version, please add the release page links of the version -->
Update the base image in KuduLite:
mcr.microsoft.com/oryx/build:20210708.1

Tested the build with github.com/Hazhzeng/KuduLite, branch: user/hazeng/funcdeplog
This branch contains the latest changes in AAPT-Antares-kudulite repository
https://github.com/Hazhzeng/kudulite/tree/user/hazeng%2Ffuncdeplog

This should fix the issue of GLIB_C building errors due to inconsistency between current remote build environment (debian 9.12) and runtime environment (debian 10.8)

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
