### PR TITLE
Auto Host Version Up pipeline title name change and remove reviewer.

### DIFF
--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -1,4 +1,4 @@
-name: Manual workflow
+name: Host version up and create PR
 
 on:
   workflow_dispatch:
@@ -36,7 +36,6 @@ jobs:
         branch: action/release.${{ github.event.inputs.targetVersion }}
         labels: |
           automated pr
-        reviewers: tsuyoshiushio
     - name: Check outputs
       run: |
           echo "Pull Request Number - ${{ steps.createPullRequest.outputs.pull-request-number }}"


### PR DESCRIPTION
Configure the Pipeline title.  

Remove the reviewer. It is automatically added by the repo's policy. 
Hi @yojagad could you approve the small change for the pipeline?

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [-] The title of the PR is clear and informative.
- [-] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
