### PR TITLE
Adding Release automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+template: |
+  # What's Changed
+  $CHANGES
+categories:
+  - title: 'Breaking'
+    label: 'type: breaking'
+  - title: 'New'
+    label: 'type: enhancement'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'Java'
+    label: 'type: java'
+  - title: 'Documentation'
+    label: 'type: documentation'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -36,6 +36,7 @@ jobs:
         branch: action/release.${{ github.event.inputs.targetVersion }}
         labels: |
           automated pr
+          dependencies
     - name: Check outputs
       run: |
           echo "Pull Request Number - ${{ steps.createPullRequest.outputs.pull-request-number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
         fetch-depth: 0
     - id: createBranch
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
+        git config --local user.email "azfuncgh@github.com"
+        git config --local user.name "Azure Functions"
         git fetch --all
         git checkout -b ${{ github.event.inputs.targetBranch }} origin/${{ github.event.inputs.targetBranch }}
         git merge dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      targetBranch:
+        description: 'TargetBranch to tag (e.g. release/3.x)'
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: dev
+        fetch-depth: 0
+    - id: createBranch
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git fetch --all
+        git checkout -b ${{ github.event.inputs.targetBranch }} origin/${{ github.event.inputs.targetBranch }}
+        git merge dev
+        git tag ${{ github.event.inputs.version }}
+        git push
+        git push origin ${{ github.event.inputs.version }}
+    - name: Release Drafter
+      uses: release-drafter/release-drafter@v5.15.0
+      with:
+        tag: ${{ github.event.inputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is release automation by GitHub Action. 

Specify two parameters. 
* Version
* Target Release Branch (e.g. release/3.x)

This will create a draft release automatically. (You need to publish it, however, it might be good to check it before you publish)

* merge dev to targetBranch
* tag on the target blanch and push it.
* Create a release
* With Change Log. (If you add label, it is automatically collect the PR with grouping with label and show the contributor's name.

![image](https://user-images.githubusercontent.com/1390976/112669399-ec52a600-8e1c-11eb-9ad3-9693a235cacb.png)

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged 

CC: @pragnagopa 