### PR TITLE
Update the GitHub Action release pipeline to enable release. 

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,18 +4,18 @@ template: |
   # What's Changed
   $CHANGES
 categories:
-  - title: 'Breaking'
-    label: 'type: breaking'
-  - title: 'New'
-    label: 'type: enhancement'
-  - title: 'Bug Fixes'
-    label: 'type: bug'
-  - title: 'Java'
-    label: 'type: java'
-  - title: 'Documentation'
-    label: 'type: documentation'
-  - title: 'Dependency Updates'
-    label: 'type: dependencies'
+  - title: '💣Breaking'
+    label: 'breaking'
+  - title: '🚀New'
+    label: 'enhancement'
+  - title: '🐛Bug Fixes'
+    label: 'bug'
+  - title: '⚡Automation'
+    label: 'automation'
+  - title: '📔Documentation'
+    label: 'documentation'
+  - title: '🔗Dependency Updates'
+    label: 'dependencies'
 
 exclude-labels:
   - 'skip-changelog'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,10 @@ jobs:
       with:
         ref: dev
         fetch-depth: 0
+        token: ${{ secrets.PIPELINE_ADMIN }}
     - id: createBranch
       run: |
+        set -e
         git config --local user.email "azfuncgh@github.com"
         git config --local user.name "Azure Functions"
         git fetch --all
@@ -26,6 +28,8 @@ jobs:
         git tag ${{ github.event.inputs.version }}
         git push
         git push origin ${{ github.event.inputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PIPELINE_ADMIN }}  
     - name: Release Drafter
       uses: release-drafter/release-drafter@v5.15.0
       with:


### PR DESCRIPTION
This pull request adding feature for the automated pipeline.  For the automated Release process, we need a permission. 
I add a secret for upgrade the permission for a bot. 

* Adding Permission to merge and release. 
* Adding fancy icon for the automated release.

![image](https://user-images.githubusercontent.com/1390976/113971795-4f194980-97ee-11eb-8acd-fe982659b04c.png)

## Documentation

[Preview: Release Images for Linux Dedicated (GitHub Action)](https://github.com/Azure/azure-functions-docker/wiki/Preview:-Release-Images-for-Linux-Dedicated-(GitHub-Action))

CC: @pragnagopa 
### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged 