### PR TITLE
fix: node 14 core tools is not published

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Linux amd64 Tags
 | `3.0-node12-slim`                         | [Dockerfile](host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile)       | Debian 10  |
 | `3.0-node12-appservice`                   | [Dockerfile](host/3.0/buster/amd64/node/node12/node12-appservice.Dockerfile) | Debian 10  |
 | `3.0-node12-core-tools`                   | [Dockerfile](host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile) | Debian 9  |
+| `3.0-node14`                              | [Dockerfile](host/3.0/buster/amd64/node/node14/node14.Dockerfile)            | Debian 10  |
+| `3.0-node14-slim`                         | [Dockerfile](host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile)       | Debian 10  |
+| `3.0-node14-appservice`                   | [Dockerfile](host/3.0/buster/amd64/node/node14/node14-appservice.Dockerfile) | Debian 10  |
+| `3.0-node14-core-tools`                   | [Dockerfile](host/3.0/buster/amd64/node/node14/node14-core-tools.Dockerfile) | Debian 9  |
 
 #### Powershell
 

--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -510,14 +510,18 @@ stages:
           set -e
           docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools
           docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools
-    
+          docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-core-tools   
+
           docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-core-tools   
           docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
           docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
-             
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node14-core-tools
+
           docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-core-tools   
           docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools
           docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools
+          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node14-core-tools
+
 
         displayName: tag node images
         continueOnError: false
@@ -535,12 +539,13 @@ stages:
             echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
             exit 1;
           fi
-          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-core-tools --format='{{.Id}}'`
-          MajorImageId=`docker image inspect $TARGET_REGISTRY/node:$(MajorVersion)-core-tools --format='{{.Id}}'`
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/node:$(MajorVersion)-node14-core-tools --format='{{.Id}}'`
           if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
             echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
             exit 1;
           fi
+
           ActualVersion=`docker run $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools func --version`
           if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
             echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
@@ -553,6 +558,12 @@ stages:
             exit 1;
           fi          
           docker run $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools az --version
+          ActualVersion=`docker run $TARGET_REGISTRY/node:$(MajorVersion)-node14-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi          
+          docker run $TARGET_REGISTRY/node:$(MajorVersion)-node14-core-tools az --version          
         displayName: test node images
         continueOnError: false        
       - bash: |
@@ -560,11 +571,13 @@ stages:
           docker push $TARGET_REGISTRY/node:$(TargetVersion)-core-tools
           docker push $TARGET_REGISTRY/node:$(TargetVersion)-node10-core-tools
           docker push $TARGET_REGISTRY/node:$(TargetVersion)-node12-core-tools
+          docker push $TARGET_REGISTRY/node:$(TargetVersion)-node14-core-tools
 
           docker push $TARGET_REGISTRY/node:$(MajorVersion)-core-tools
           docker push $TARGET_REGISTRY/node:$(MajorVersion)-node10-core-tools
           docker push $TARGET_REGISTRY/node:$(MajorVersion)-node12-core-tools
-    
+          docker push $TARGET_REGISTRY/node:$(MajorVersion)-node14-core-tools
+
           docker system prune -a -f
         displayName: push node images
         continueOnError: false

--- a/test/image-healthcheck.yml
+++ b/test/image-healthcheck.yml
@@ -48,6 +48,13 @@ steps:
     displayName: Node12 core-tools 
   - bash: |
       set -e
+      ImageName="mcr.microsoft.com/azure-functions/node:3.0-node14-core-tools"
+      docker run $ImageName az --version
+      CurrentVersion=`docker run $ImageName func --version`
+      echo "Azure Functions Core Tools: Current: ${CurrentVersion} Latest: $(LatestVersion)"
+    displayName: Node14 core-tools 
+  - bash: |
+      set -e
       ImageName="mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools"
       docker run $ImageName az --version
       CurrentVersion=`docker run $ImageName func --version`


### PR DESCRIPTION
I found that node 14 core tools is not published.

* Add publish section for node 14 core tools
* Add node 14 core tools for health check pipeline 
* Update Readme

CC: @pragnagopa 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
