### PR TITLE
Updated build pipelines to support new versioning 3.x.x

### DIFF
--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -15,7 +15,7 @@ trigger:
   branches:
     include:
       - dev
-      - refs/tags/3.0.*
+      - refs/tags/3.*.*
       - release/3.x
   paths:
     include:

--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -14,7 +14,7 @@ trigger:
   branches:
     include:
       - dev
-      - refs/tags/3.0.*
+      - refs/tags/3.*.*
       - release/3.x
   paths:
     include:

--- a/host/3.0/nanoserver-build.yml
+++ b/host/3.0/nanoserver-build.yml
@@ -14,7 +14,7 @@ trigger:
   branches:
     include:
       - dev
-      - refs/tags/3.0.*
+      - refs/tags/3.*.*
       - release/3.x
   paths:
     include:

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -13,7 +13,7 @@ trigger:
   branches:
     include:
       - dev
-      - refs/tags/3.0.*
+      - refs/tags/3.*.*
       - release/3.x
   paths:
     include:

--- a/host/3.0/powershell-build.yml
+++ b/host/3.0/powershell-build.yml
@@ -13,7 +13,7 @@ trigger:
   branches:
     include:
       - dev
-      - refs/tags/3.0.*
+      - refs/tags/3.*.*
       - release/3.x
   paths:
     include:

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -11,7 +11,7 @@ trigger:
   branches:
     include:
       - dev
-      - refs/tags/3.0.*
+      - refs/tags/3.*.*
       - release/3.x
   paths:
     include:


### PR DESCRIPTION
Updated the 3.0 build pipelines to support 3.x.x versioning.  Previously, build pipelines were triggered by releases with the tag 3.0.* but the newest host version to be released is 3.1.0.  To update devOps I changed the triggers of all 3.0 pipelines. 


<!-- If you are doing releasing a new host version, please add the release page links of the version -->
Releasing new Host versions.
[V3 Release](PASTE_V3_LINK_HERE)
[V2 Release](PASTE_V2_LINK_HERE)

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
