### PR TITLE
Add 3.0 image push 

### DIFF
--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -49,6 +49,18 @@ steps:
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/base:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/base:$(TargetVersion)-appservice
 
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/dotnet:3.0
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/dotnet:3.0-slim
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:3.0-appservice
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:3.0-dotnet3-appservice
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:3.0-appservice-quickstart
+       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-arm32v7 $TARGET_REGISTRY/dotnet:3.0-arm32v7
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-bionic-arm32v7 $TARGET_REGISTRY/dotnet:3.0-bionic-arm32v7
+
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/base:3.0
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/base:3.0-slim
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/base:3.0-appservice
+
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
@@ -59,6 +71,17 @@ steps:
       docker push $TARGET_REGISTRY/base:$(TargetVersion)
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-appservice
+
+      docker push $TARGET_REGISTRY/dotnet:3.0
+      docker push $TARGET_REGISTRY/dotnet:3.0-slim
+      docker push $TARGET_REGISTRY/dotnet:3.0-appservice
+      docker push $TARGET_REGISTRY/dotnet:3.0-dotnet3-appservice
+      docker push $TARGET_REGISTRY/dotnet:3.0-appservice-quickstart
+      docker push $TARGET_REGISTRY/dotnet:3.0-arm32v7
+      docker push $TARGET_REGISTRY/dotnet:3.0-bionic-arm32v7
+      docker push $TARGET_REGISTRY/base:3.0
+      docker push $TARGET_REGISTRY/base:3.0-slim
+      docker push $TARGET_REGISTRY/base:3.0-appservice
 
       docker system prune -a -f
     displayName: tag and push dotnet images
@@ -80,6 +103,17 @@ steps:
       docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-appservice
       docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-appservice-quickstart
 
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0 $TARGET_REGISTRY/dotnet-isolated:3.0
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-slim $TARGET_REGISTRY/dotnet-isolated:3.0-slim
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-appservice $TARGET_REGISTRY/dotnet-isolated:3.0-appservice
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-appservice $TARGET_REGISTRY/dotnet-isolated:3.0-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0 $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-slim $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0-slim
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-appservice $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0-appservice
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated5.0-appservice $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0-appservice-quickstart
+
+
       docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)
       docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-appservice
@@ -88,6 +122,15 @@ steps:
       docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-slim
       docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-appservice
       docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated5.0-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-slim
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-appservice
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-appservice-quickstart
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0-slim
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0-appservice
+      docker push $TARGET_REGISTRY/dotnet-isolated:3.0-dotnet-isolated5.0-appservice-quickstart
 
       docker system prune -a -f
     displayName: tag and push dotnet-isolated images
@@ -123,6 +166,26 @@ steps:
       docker tag mcr.microsoft.com/java/maven:8-zulu-debian10 $TARGET_REGISTRY/java:$(TargetVersion)-java8-build
       docker tag mcr.microsoft.com/java/maven:11-zulu-debian10 $TARGET_REGISTRY/java:$(TargetVersion)-java11-build
 
+
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8 $TARGET_REGISTRY/java:3.0
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim $TARGET_REGISTRY/java:3.0-slim
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:3.0-appservice
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:3.0-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8 $TARGET_REGISTRY/java:3.0-java8
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim $TARGET_REGISTRY/java:3.0-java8-slim
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:3.0-java8-appservice
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:3.0-java8-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11 $TARGET_REGISTRY/java:3.0-java11
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-slim $TARGET_REGISTRY/java:3.0-java11-slim
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice $TARGET_REGISTRY/java:3.0-java11-appservice
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice $TARGET_REGISTRY/java:3.0-java11-appservice-quickstart
+
+      docker tag mcr.microsoft.com/java/maven:8-zulu-debian10 $TARGET_REGISTRY/java:3.0-java8-build
+      docker tag mcr.microsoft.com/java/maven:11-zulu-debian10 $TARGET_REGISTRY/java:3.0-java11-build
+
+
       docker push $TARGET_REGISTRY/java:$(TargetVersion)
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-appservice
@@ -140,6 +203,24 @@ steps:
 
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-build
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11-build
+
+      docker push $TARGET_REGISTRY/java:3.0
+      docker push $TARGET_REGISTRY/java:3.0-slim
+      docker push $TARGET_REGISTRY/java:3.0-appservice
+      docker push $TARGET_REGISTRY/java:3.0-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/java:3.0-java8
+      docker push $TARGET_REGISTRY/java:3.0-java8-slim
+      docker push $TARGET_REGISTRY/java:3.0-java8-appservice
+      docker push $TARGET_REGISTRY/java:3.0-java8-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/java:3.0-java11
+      docker push $TARGET_REGISTRY/java:3.0-java11-slim
+      docker push $TARGET_REGISTRY/java:3.0-java11-appservice
+      docker push $TARGET_REGISTRY/java:3.0-java11-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/java:3.0-java8-build
+      docker push $TARGET_REGISTRY/java:3.0-java11-build
 
       docker system prune -a -f
     displayName: tag and push java images
@@ -180,6 +261,27 @@ steps:
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node14-appservice-quickstart
 
 
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node8-appservice $TARGET_REGISTRY/node:3.0-node8-appservice
+
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10 $TARGET_REGISTRY/node:3.0
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim $TARGET_REGISTRY/node:3.0-slim
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:3.0-appservice
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:3.0-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10 $TARGET_REGISTRY/node:3.0-node10
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-slim $TARGET_REGISTRY/node:3.0-node10-slim
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:3.0-node10-appservice
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node10-appservice $TARGET_REGISTRY/node:3.0-node10-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12 $TARGET_REGISTRY/node:3.0-node12
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-slim $TARGET_REGISTRY/node:3.0-node12-slim
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:3.0-node12-appservice
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node12-appservice $TARGET_REGISTRY/node:3.0-node12-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14 $TARGET_REGISTRY/node:3.0-node14
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-slim $TARGET_REGISTRY/node:3.0-node14-slim
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-appservice $TARGET_REGISTRY/node:3.0-node14-appservice
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node14-appservice $TARGET_REGISTRY/node:3.0-node14-appservice-quickstart
+
       docker push $TARGET_REGISTRY/node:$(TargetVersion)
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-appservice
@@ -202,6 +304,28 @@ steps:
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node14-appservice
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node14-appservice-quickstart
 
+
+      docker push $TARGET_REGISTRY/node:3.0
+      docker push $TARGET_REGISTRY/node:3.0-slim
+      docker push $TARGET_REGISTRY/node:3.0-appservice
+      docker push $TARGET_REGISTRY/node:3.0-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/node:3.0-node8-appservice
+
+      docker push $TARGET_REGISTRY/node:3.0-node10
+      docker push $TARGET_REGISTRY/node:3.0-node10-slim
+      docker push $TARGET_REGISTRY/node:3.0-node10-appservice
+      docker push $TARGET_REGISTRY/node:3.0-node10-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/node:3.0-node12
+      docker push $TARGET_REGISTRY/node:3.0-node12-slim
+      docker push $TARGET_REGISTRY/node:3.0-node12-appservice
+      docker push $TARGET_REGISTRY/node:3.0-node12-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/node:3.0-node14
+      docker push $TARGET_REGISTRY/node:3.0-node14-slim
+      docker push $TARGET_REGISTRY/node:3.0-node14-appservice
+      docker push $TARGET_REGISTRY/node:3.0-node14-appservice-quickstart
 
       docker system prune -a -f
     displayName: tag and push node images
@@ -231,6 +355,23 @@ steps:
       docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice
       docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-quickstart
 
+
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6 $TARGET_REGISTRY/powershell:3.0
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-slim $TARGET_REGISTRY/powershell:3.0-slim
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-appservice $TARGET_REGISTRY/powershell:3.0-appservice
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-appservice $TARGET_REGISTRY/powershell:3.0-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6 $TARGET_REGISTRY/powershell:3.0-powershell6
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-slim $TARGET_REGISTRY/powershell:3.0-powershell6-slim
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-appservice $TARGET_REGISTRY/powershell:3.0-powershell6-appservice
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell6-appservice $TARGET_REGISTRY/powershell:3.0-powershell6-appservice-quickstart
+
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7 $TARGET_REGISTRY/powershell:3.0-powershell7
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-slim $TARGET_REGISTRY/powershell:3.0-powershell7-slim
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:3.0-powershell7-appservice
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:3.0-powershell7-appservice-quickstart
+
+
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice
@@ -245,6 +386,23 @@ steps:
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-slim
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-quickstart
+
+
+      docker push $TARGET_REGISTRY/powershell:3.0
+      docker push $TARGET_REGISTRY/powershell:3.0-slim
+      docker push $TARGET_REGISTRY/powershell:3.0-appservice
+      docker push $TARGET_REGISTRY/powershell:3.0-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell6
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell6-slim
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell6-appservice
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell6-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell7
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell7-slim
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell7-appservice
+      docker push $TARGET_REGISTRY/powershell:3.0-powershell7-appservice-quickstart
+
 
       docker system prune -a -f
     displayName: tag and push powershell images
@@ -299,6 +457,38 @@ steps:
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-quickstart
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-buildenv
 
+
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:3.0
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:3.0-slim
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:3.0-appservice
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:3.0-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:3.0-buildenv
+
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:3.0-python3.6
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:3.0-python3.6-slim
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:3.0-python3.6-appservice
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:3.0-python3.6-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:3.0-python3.6-buildenv
+
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7 $TARGET_REGISTRY/python:3.0-python3.7
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim $TARGET_REGISTRY/python:3.0-python3.7-slim
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:3.0-python3.7-appservice
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:3.0-python3.7-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-buildenv $TARGET_REGISTRY/python:3.0-python3.7-buildenv
+
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8 $TARGET_REGISTRY/python:3.0-python3.8
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-slim $TARGET_REGISTRY/python:3.0-python3.8-slim
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:3.0-python3.8-appservice
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:3.0-python3.8-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-buildenv $TARGET_REGISTRY/python:3.0-python3.8-buildenv
+
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9 $TARGET_REGISTRY/python:3.0-python3.9
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-slim $TARGET_REGISTRY/python:3.0-python3.9-slim
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:3.0-python3.9-appservice
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:3.0-python3.9-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-buildenv $TARGET_REGISTRY/python:3.0-python3.9-buildenv
+
+
       docker push $TARGET_REGISTRY/python:$(TargetVersion)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice
@@ -328,6 +518,37 @@ steps:
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-quickstart
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-buildenv
+
+
+      docker push $TARGET_REGISTRY/python:3.0
+      docker push $TARGET_REGISTRY/python:3.0-slim
+      docker push $TARGET_REGISTRY/python:3.0-appservice
+      docker push $TARGET_REGISTRY/python:3.0-appservice-quickstart
+      docker push $TARGET_REGISTRY/python:3.0-buildenv
+
+      docker push $TARGET_REGISTRY/python:3.0-python3.6
+      docker push $TARGET_REGISTRY/python:3.0-python3.6-slim
+      docker push $TARGET_REGISTRY/python:3.0-python3.6-appservice
+      docker push $TARGET_REGISTRY/python:3.0-python3.6-appservice-quickstart
+      docker push $TARGET_REGISTRY/python:3.0-python3.6-buildenv
+
+      docker push $TARGET_REGISTRY/python:3.0-python3.7
+      docker push $TARGET_REGISTRY/python:3.0-python3.7-slim
+      docker push $TARGET_REGISTRY/python:3.0-python3.7-appservice
+      docker push $TARGET_REGISTRY/python:3.0-python3.7-appservice-quickstart
+      docker push $TARGET_REGISTRY/python:3.0-python3.7-buildenv
+
+      docker push $TARGET_REGISTRY/python:3.0-python3.8
+      docker push $TARGET_REGISTRY/python:3.0-python3.8-slim
+      docker push $TARGET_REGISTRY/python:3.0-python3.8-appservice
+      docker push $TARGET_REGISTRY/python:3.0-python3.8-appservice-quickstart
+      docker push $TARGET_REGISTRY/python:3.0-python3.8-buildenv
+
+      docker push $TARGET_REGISTRY/python:3.0-python3.9
+      docker push $TARGET_REGISTRY/python:3.0-python3.9-slim
+      docker push $TARGET_REGISTRY/python:3.0-python3.9-appservice
+      docker push $TARGET_REGISTRY/python:3.0-python3.9-appservice-quickstart
+      docker push $TARGET_REGISTRY/python:3.0-python3.9-buildenv
 
       docker system prune -a -f
     displayName: tag and push python images


### PR DESCRIPTION
[v3 publish pipeline](https://azure-functions.visualstudio.com/azure-functions-docker/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=32&nonce=hSO3C5Yy0YsMFa4xyfhtDA%3D%3D&branch=dev) requires to run two times. If you want to publish `3.2.0` version, you need to run twice. One for `targetVersion=3.2.0` the other is `targetVersion=3.0`.   

This change assume for the V3 version, when we push the version `3.a.b` it will push `3.0` version as well. So that users can run this pipeline only one time.  It is a not good practice to publish 3.0 has the same version as 3.2.0, it is because this numbering system has been changed during the operation. v4 versioning won't have this issue.

After this PR has been merged, we need to update the following documentation. 
https://github.com/Azure/azure-functions-docker/wiki/Preview:-Release-Images-for-Linux-Dedicated-(GitHub-Action)
https://azfunc.visualstudio.com/Azure%20Functions/_release?_a=releases&view=mine&definitionId=20

FYI @CooperLink  @pgombar

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
