### PR TITLE
Update python38-core-tools.Dockerfile

### DIFF
--- a/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+FROM mcr.microsoft.com/vscode/devcontainers/python:0.201.8-3.8
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Azure CLI doesn't support bullseye for now.  However, python image looks upgraded to the bullseye. 
I fix the version for time being. 

Currently this issue, block releasing Azure Functions Core Tools image. 

## Context 
We found the Core Tools Publish pipeline is fail by the following error.  The pipeline is for releasing Core Tools docker images that runs nightly. The image is used mainly for devcontainer. 
https://azure-functions.visualstudio.com/azure-functions-docker/_build/results?buildId=11733&view=results

That caused by the update of the OS on the python official image. 

```
#5 3.229 E: The repository 'https://packages.microsoft.com/repos/azure-cli bullseye Release' does not have a Release file.
```

We found that python official images has move from buster to bullseye. 
https://github.com/docker-library/python/pull/633

Found `mcr.microsoft.com/vscode/devcontainers/python:0.201.8-3.8` is still on the buster. 
We are rollback the change or use new ways once Azure CLI team release the Bullseye. 

https://github.com/Azure/azure-cli/pull/19370

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).


<!-- Thanks for using the checklist -->
