### PR TITLE
Upgrade PowerShell to 7.0.7

### DIFF
--- a/host/4/bullseye/amd64/powershell/powershell7-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-core-tools.Dockerfile
@@ -11,7 +11,7 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-ARG PS_VERSION=7.0.3
+ARG PS_VERSION=7.0.7
 ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.10_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->


<!-- If you are doing releasing a new host version, please add the release page links of the version -->

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->
Resolves #475

Apparently, PowerShell 7.0.3 cannot be installed on Debian 11. We don't have a reason to install an old version anyway, so upgrading to 7.0.6.

PowerShell is now successfully installed, and the build hits another (I believe unrelated) problem:

> The repository 'https://packages.microsoft.com/repos/azure-cli bullseye Release' does not have a Release file.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
