### PR TITLE
U/clink/update publishing pipelines ubuntu

### DIFF
--- a/host/2.0-upgrade/publish-appservice-stage.yml
+++ b/host/2.0-upgrade/publish-appservice-stage.yml
@@ -1,6 +1,7 @@
-# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v2 upgrade stage release
-queue: Hosted Ubuntu 1604
 trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v2 upgrade stage release
+pool:
+    vmImage: 'Ubuntu-latest'
 
 steps:
   - bash: |

--- a/host/2.0-upgrade/publish-appservice-stage.yml
+++ b/host/2.0-upgrade/publish-appservice-stage.yml
@@ -1,3 +1,4 @@
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v2 upgrade stage release
 queue: Hosted Ubuntu 1604
 trigger: none
 

--- a/host/3.0/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/3.0/publish-appservice-stage-sovereign-clouds.yml
@@ -1,5 +1,6 @@
 queue: Hosted Ubuntu 1604
 trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v3 stage release sovereign cloud
 parameters:
   - name: stages
     type: object

--- a/host/3.0/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/3.0/publish-appservice-stage-sovereign-clouds.yml
@@ -1,6 +1,8 @@
-queue: Hosted Ubuntu 1604
 trigger: none
 # Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v3 stage release sovereign cloud
+pool:
+    vmImage: 'Ubuntu-latest'
+
 parameters:
   - name: stages
     type: object

--- a/host/3.0/publish-appservice-stage.yml
+++ b/host/3.0/publish-appservice-stage.yml
@@ -1,6 +1,7 @@
-queue: Hosted Ubuntu 1604
 trigger: none
 # Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v3 stage release
+pool:
+    vmImage: 'Ubuntu-latest'
 
 steps:
   - bash: |

--- a/host/3.0/publish-appservice-stage.yml
+++ b/host/3.0/publish-appservice-stage.yml
@@ -1,5 +1,6 @@
 queue: Hosted Ubuntu 1604
 trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v3 stage release
 
 steps:
   - bash: |

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -1,3 +1,4 @@
+# Publish pipelines are triggered via HTTP method in release pipeline. See v3 publish
 stages:
 - stage: Linux_Images
   jobs:

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -4,7 +4,7 @@ stages:
   jobs:
   - job: Publish_all
     pool: 
-      vmImage: ubuntu-18.04
+      vmImage: 'Ubuntu-latest'
     steps:
     - bash: |
         echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io

--- a/host/4/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/4/publish-appservice-stage-sovereign-clouds.yml
@@ -1,6 +1,8 @@
-# Does not currently have a pipeline to call HTTP 
-queue: Hosted Ubuntu 1604
 trigger: none
+# Does not currently have a pipeline to call HTTP 
+pool:
+    vmImage: 'Ubuntu-latest'
+
 parameters:
   - name: stages
     type: object

--- a/host/4/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/4/publish-appservice-stage-sovereign-clouds.yml
@@ -1,3 +1,4 @@
+# Does not currently have a pipeline to call HTTP 
 queue: Hosted Ubuntu 1604
 trigger: none
 parameters:

--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -1,6 +1,7 @@
-# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v4 stage release
-queue: Hosted Ubuntu 1604
 trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v4 stage release
+pool:
+    vmImage: 'Ubuntu-latest'
 
 steps:
   - bash: |

--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -1,3 +1,4 @@
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v4 stage release
 queue: Hosted Ubuntu 1604
 trigger: none
 

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -1,6 +1,7 @@
-# Publish pipelines are triggered via HTTP method in release pipeline. See v4 publish
-queue: Hosted Ubuntu 1604
 trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See v4 publish
+pool:
+    vmImage: 'Ubuntu-latest'
 
 steps:
   - bash: |

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -1,3 +1,4 @@
+# Publish pipelines are triggered via HTTP method in release pipeline. See v4 publish
 queue: Hosted Ubuntu 1604
 trigger: none
 


### PR DESCRIPTION

### PR information
On the 11th of October, the Azure Functions release loop had a blocker when the Ubuntu 1604 images used for agents on the publishing pipelines were blocked from beginning.  During that time period, Azure Devops introduced an intentional brown-out for agents targetted at Ubuntu 1604 in advance of deprecation. 

This PR updates publish pipelines in currently supported versions to use 'Ubuntu-latest' images to run the pipeline steps.  It also updates the syntax for agents from the deprecated `queue` syntax to newer, supported syntax.  Relying on Ubuntu-Latest from the[ Microsoft Hosted Agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml) will avoid this problem in the future.  This will help the pipeline operate reliably and securely.

This PR also adds comments to the publish pipelines to help release engineers find pipelines more easily.  The comments also explain the trigger mechanism. Chose to include comments after personal confusion and ensuing conversation with @TsuyoshiUshio 

<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
