### PR TITLE
Updating host version to 4.0.1.16815

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-appservice.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,21 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Check if this is needed
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -1,21 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Check if this is needed
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/java/java11/java11-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-appservice.Dockerfile
@@ -1,22 +1,17 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 ARG JAVA_VERSION=11u7
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -1,22 +1,17 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 ARG JAVA_VERSION=11u7
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -1,22 +1,17 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 ARG JAVA_VERSION=11u7
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/java/java8/java8-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-appservice.Dockerfile
@@ -1,22 +1,17 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 ARG JAVA_VERSION=8u252
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 RUN echo "HOST_VARSION: "${HOST_VERSION}
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -1,21 +1,16 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 ARG JAVA_VERSION=8u252
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -1,21 +1,16 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 ARG JAVA_VERSION=8u252
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/node/node14/node14-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-appservice.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \    
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/node/node16/node16-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-appservice.Dockerfile
@@ -1,17 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -1,17 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -1,17 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
@@ -1,21 +1,16 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
-
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
 # Build WebJobs.Script.WebHost from source
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     rm -rf /azure-functions-host/workers/powershell/6 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src

--- a/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
@@ -1,18 +1,13 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
-
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
 # Build WebJobs.Script.WebHost from source
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
     dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \

--- a/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
@@ -1,18 +1,13 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
-
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
 # Build WebJobs.Script.WebHost from source
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
     dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \

--- a/host/4/bullseye/amd64/python/python37/python37-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-appservice.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python38/python38-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-appservice.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python39/python39-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-appservice.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -1,20 +1,15 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.0.0-preview.5.16714
+ARG HOST_VERSION=4.0.1.16815
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
 ARG HOST_VERSION
 
-# Build requires 3.1 SDK
-COPY --from=mcr.microsoft.com/dotnet/sdk:5.0 /usr/share/dotnet /usr/share/dotnet
-
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 5) && \
-    BRANCH_NAME=release/$(echo ${HOST_VERSION} | cut -d'.' -f 1-4) && \
-    SUFFIX=$(echo ${HOST_VERSION} | cut -d'-' -f 2 | cut -d'.' -f 1-2) && \
-    git clone --branch $BRANCH_NAME https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 4) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:VersionSuffix=$SUFFIX /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 


### PR DESCRIPTION
Updating v4 images for GA.
 * Host version upgraded to 4.0.1.16815.
 * Removed an unused line which used dotnet/sdk:5.0.
 * No change in dotnet SDK/runtime in this PR.
