### PR TITLE
[V4] Switching from rc2 to nightly for dotnet runtime deps

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-appservice.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java11/java11-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-appservice.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java8/java8-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-appservice.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -37,7 +37,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -37,7 +37,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/node/node14/node14-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-appservice.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-appservice.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0-rc.2
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-rc.2-bullseye-slim
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-rc.2-bullseye-slim
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-rc.2-bullseye-slim
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now


### PR DESCRIPTION
The dotnet nightly images are [confirmed to be same bits as of the GA bits](https://twitter.com/runfaster2000/status/1455372722939310084). In this PR, I am updating the rc2 image with the nightly image for dotnet sdk & runtime deps.

We are still using rc2 of dotnet/sdk for [building & publishing](https://github.com/Azure/azure-functions-docker/blob/dev/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile#L12) the functions host project. Because some of the dependent packages for  `linux-x64` runtime (ex: `Microsoft.NETCore.App.Runtime.linux-x64`) are not yet available in public nuget feed yet. (They will be available only on Nov 8th).

There will be a follow up PR on or after 11/8th to update the remaining pieces to use GA version of dotnet sdk images.