### PR TITLE
Generate v3 Artifacts on Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,7 @@ jobs:
         git checkout -b ${{ github.event.inputs.targetBranch }} origin/${{ github.event.inputs.targetBranch }}
         git merge dev
         ./host/3.0/buster/amd64/base/generate-composite.sh -r all
-        git add . 
-        git commit -m "Generated Images for Release"
+        zip -r version3images.zip ./host/3.0/buster/amd64/out/
         git tag ${{ github.event.inputs.version }}
         git push
         git push origin ${{ github.event.inputs.version }}
@@ -48,5 +47,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.release.outputs.upload_url }}
-        asset_path: ./host/3.0/buster/amd64/java/java11-appservice.Dockerfile
-        asset_name: java11image
+        asset_path: ./version3images.zip
+        asset_name: version3images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         git checkout -b ${{ github.event.inputs.targetBranch }} origin/${{ github.event.inputs.targetBranch }}
         git merge dev
         ./host/3.0/buster/amd64/base/generate-composite.sh -r all
-        zip -r version3images.zip ./host/3.0/buster/amd64/out/
+        zip -r version3images.zip ./host/3.0/buster/amd64/release/
         git tag ${{ github.event.inputs.version }}
         git push
         git push origin ${{ github.event.inputs.version }}


### PR DESCRIPTION


### PR information

PR #516 began a process to introduce templating to dockerfiles.  Part of that effort includes generating and uploading release assets as part of the pipeline.  Code introduced in release.yml, removed in this commit, was previously generating the dockerfiles and committing them to the release branch. The Git commit in this case is blocking release due to merge conflicts. 

As part of the effort to remove release/ branches, this PR produces build artifacts, zips them, and uploads them to a release tag on github instead of relying on git committing to the soon to be deprecated release branches.
https://github.com/Azure/azure-functions-docker/issues/554

<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
