### PR TITLE
Moving away from nightly image of dotnet/runtime-deps

### DIFF
--- a/host/4/bullseye/amd64/base/host.Dockerfile
+++ b/host/4/bullseye/amd64/base/host.Dockerfile
@@ -1,6 +1,6 @@
 ARG HOST_VERSION=4.0.1.16815
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-core-tools.Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/runtime:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java11/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11/java11-composite.template
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION=11u7
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/java/java8/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8/java8-composite.template
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION=8u252
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/node/node14/node14-composite.template
+++ b/host/4/bullseye/amd64/node/node14/node14-composite.template
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-composite.template
+++ b/host/4/bullseye/amd64/node/node16/node16-composite.template
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \


### PR DESCRIPTION
Fixes #556 

For making the V4 images ready for GA day, we [used ](https://github.com/Azure/azure-functions-docker/pull/537)the nightly images of `dotnet/runtime-deps`. In this PR, we are removing the nightly ones. Thanks to Cooper's refactoring. Only few files need the change.

Also switched the dotnet sdk image used for building code from rc2 version to RTM, since the dependent packages are now available in public nuget gallery.
