### PR TITLE
Include Microsoft.AspNetCore.App shared framework from dotnet/aspnet image in dotnet-isolated images.

### DIFF
--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -1,3 +1,6 @@
+# Include ASP.NET Core shared framework from dotnet/aspnet image.
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS aspnet5
+
 FROM mcr.microsoft.com/dotnet/runtime:5.0
 ARG HOST_VERSION
 
@@ -9,6 +12,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY --from=aspnet5 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 EXPOSE 2222 80
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -1,3 +1,6 @@
+# Include ASP.NET Core shared framework from dotnet/aspnet image.
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0 AS aspnet6
+
 FROM mcr.microsoft.com/dotnet/runtime:6.0.0
 ARG HOST_VERSION
 
@@ -13,6 +16,7 @@ RUN apt-get update && \
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY --from=aspnet6 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 EXPOSE 2222 80
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -1,5 +1,5 @@
 # Include ASP.NET Core shared framework from dotnet/aspnet image.
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0 AS aspnet6
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS aspnet6
 
 FROM mcr.microsoft.com/dotnet/runtime:6.0.0
 ARG HOST_VERSION


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/608

Since .NET Core 3.0, many ASP.NET Core assemblies are no longer published to NuGet as packages. Instead, the assemblies are included in the `Microsoft.AspNetCore.App` shared framework, which is installed with the .NET Core SDK and runtime installers.

Our current images are not including this `Microsoft.AspNetCore.App` shared framework. So any customer code which is relying on types from this shared framework (by including `<FrameworkReference Include="Microsoft.AspNetCore.App" />` or `<PackageReference Include="Microsoft.AspNetCore.App" />` in csproj) will fail to build. Full list of types are present [here](https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-6.0&tabs=visual-studio#remove-obsolete-package-references). Click on the "_Click to expand the list of packages no longer being produced_"

Changes are made to V3 and V4 isolated docker images. In-proc works fine, so no change needed.
