### PR TITLE
Fix 'Publish KEDA Cosmos DB scaler' pipeline

### DIFF
--- a/keda/publish-keda-cosmosdb-scaler.yml
+++ b/keda/publish-keda-cosmosdb-scaler.yml
@@ -19,7 +19,7 @@ steps:
       set -e
 
       ORGANIZATION_NAME=kedacore
-      IMAGE_NAME=keda-external-scaler-azure-cosmos-db
+      IMAGE_NAME=external-scaler-azure-cosmos-db
 
       ACR_NAME=azurefunctions
       ACR_SERVER=$ACR_NAME.azurecr.io

--- a/keda/publish-keda-cosmosdb-scaler.yml
+++ b/keda/publish-keda-cosmosdb-scaler.yml
@@ -41,7 +41,8 @@ steps:
           --name $ACR_NAME \
           --username $ACR_USERNAME \
           --password $ACR_PASSWORD \
-          --image $ACR_REPOSITORY@$digest
+          --image $ACR_REPOSITORY@$digest \
+          --yes
       done
 
       # Push all available image versions from GHCR to ACR.


### PR DESCRIPTION
The pipeline used to fail with error below if there were untagged manifests to be deleted.

```log
Deleting untagged manifest with digest: [sha256:495d343626ae165154fecc043c4ded30a1a3bcd329333026fad6125c08dbada5].
ERROR: Unable to prompt for confirmation as no tty available. Use --yes.
##[error]Bash exited with code '1'.
Finishing: Push KEDA Cosmos DB scaler images
```

Last week was the first time we encountered the issue. Verified that [pipeline runs without error](https://azure-functions.visualstudio.com/azure-functions-docker/_build/results?buildId=12997&view=results) with the fix applied.

---
KEDA maintainers decided to rename the image name from `keda-external-scaler-azure-cosmos-db` to `external-scaler-azure-cosmos-db`. We will republish the image with new name on MCR to avoid inconsistency and confusion.

---
### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
