### PR TITLE
Fix the indentation issue for v4 Core Tools pipeline

### DIFF
--- a/host/4/core-tools-publish.yml
+++ b/host/4/core-tools-publish.yml
@@ -519,15 +519,15 @@ stages:
         continueOnError: false
         condition: ne(variables['SkipProduction'], 'true')
 
-        - bash: |
-          set -e
-          docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools
+      - bash: |
+        set -e
+        docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools
 
-          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-core-tools   
-          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node16-core-tools
+        docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-core-tools   
+        docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(TargetVersion)-node16-core-tools
 
-          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-core-tools   
-          docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node16-core-tools
+        docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-core-tools   
+        docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node16-core-tools $TARGET_REGISTRY/node:$(MajorVersion)-node16-core-tools
 
 
         displayName: tag node16 images


### PR DESCRIPTION
The v4 Core Tools yaml file for AzureDevOps cause parsing pipeline YAML  Line 522. It looks issue of indentation.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.

<!-- Thanks for using the checklist -->
