### PR TITLE
Update the Readme for fixing image name for v4 core tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Linux amd64 Tags
 | `4`                                      | Debian 10  |
 | `4-slim`                                 | Debian 10  |
 | `4-appservice`, `4-dotnet3-appservice` | Debian 10  |
-| `4-dotnet3-core-tools` |  Debian 10  |
+| `4-dotnet6-core-tools` |  Debian 10  |
 
 
 `mcr.microsoft.com/azure-functions/dotnet-isolated`
@@ -29,7 +29,7 @@ Linux amd64 Tags
 | `4`                                      | Debian 10  |
 | `4-dotnet-isolated5.0-slim`                               | Debian 10  |
 | `4-appservice`, `4-dotnet-isolated5.0-appservice` |Debian 10  |
-| `4-dotnet-isolated5.0-core-tools` | Debian 10  |
+| `4-dotnet-isolated6.0-core-tools` | Debian 10  |
 
 #### Node
 
@@ -76,7 +76,6 @@ Linux amd64 Tags
 | `4`, `4-java8`                       |  Debian 10  |
 | `4-slim`, `4-java8-slim`             |  Debian 10  |
 | `4-appservice`, `4-java8-appservice` |  Debian 10  |
-| `4-java8-core-tools`                   |  Debian 10   |
 | `4-java8-build`               | Debian 10   |
 | `4-java11`                             |Debian 10  |
 | `4-java11-slim`                        |  Debian 10  |


### PR DESCRIPTION
Fix the wrong image name for v4 core tools 
@pragnagopa 

I also remove v4 java8 it looks not supported.

Fix
https://github.com/Azure/azure-functions-docker/issues/578 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
