### PR TITLE
Removed all references to Dotnet6 nightly

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-core-tools.Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/nightly/sdk:6.0.100
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -37,7 +37,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -37,7 +37,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -35,7 +35,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
@@ -41,7 +41,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     find /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/bin/runtimes/ -mindepth 1 -type d -not -name "linux-x64" -prune -exec rm -rf {} + && \
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
@@ -38,7 +38,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now


### PR DESCRIPTION
PR to address two issues that have been filed recently regarding the use of dotnet 6 nightly in images.  Functions v4 Powershell  7 appservice image was using a nightly aspnet version and other non-appservice images were using various nightly dotnet sdks for runtime.  

Related Issues : 
https://github.com/Azure/azure-functions-docker/issues/591
https://github.com/Azure/azure-functions-docker/issues/585

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
