### PR TITLE
Include dotnet3.1 in v4 powershell7 coretools

### DIFF
--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100 as dotnet6
+FROM mcr.microsoft.com/dotnet/sdk:6.0.200 as dotnet6
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 # Avoid warnings by switching to noninteractive

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
@@ -1,7 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100
-
-# Powershell Core Tools requires 3.1 for now
-COPY --from=mcr.microsoft.com/dotnet/core/aspnet:3.1 /usr/share/dotnet /usr/share/dotnet
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
@@ -1,3 +1,4 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 as dotnet6
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 # Avoid warnings by switching to noninteractive
@@ -27,6 +28,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 
 ENV FUNCTIONS_WORKER_RUNTIME=powershell
 ENV FUNCTIONS_WORKER_RUNTIME_VERSION=~7
+COPY --from=dotnet6  [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100
 
+# Powershell Core Tools requires 3.1 for now
+COPY --from=mcr.microsoft.com/dotnet/core/aspnet:3.1 /usr/share/dotnet /usr/share/dotnet
+
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Copied mechanism for using dotnet 3.1 from each of the other powershell dockerfiles to the core-tools dockerfile in response to a bug filed earlier today.  This should make dotnet 3.1 available in these images. But, I need some help to understand how I can test to ensure that this fix resolves the bug

https://github.com/Azure/azure-functions-docker/issues/590

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
