### PR TITLE
Update references for dotnet/sdk:6.0.100-rc.2 to dotnet/sdk:6.0.100

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -1,7 +1,7 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
 ARG JAVA_VERSION=11u11
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -1,7 +1,7 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
 ARG JAVA_VERSION=11u11
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -1,7 +1,7 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
 ARG JAVA_VERSION=8u292
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -1,7 +1,7 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
 ARG JAVA_VERSION=8u292
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-appservice.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell7.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -1,6 +1,6 @@
 # Build the runtime from source
 ARG HOST_VERSION=4.1.3
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100-rc.2 AS runtime-image
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS runtime-image
 ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false


### PR DESCRIPTION
Removed all references to RC2 in response to various comments recently.  RC.2 was a nightly version of dotnet that was used before GA was available for dotnet6.  

Problems : 
https://github.com/Azure/azure-functions-docker/pull/570#discussion_r781681203
https://github.com/Azure/azure-functions-docker/pull/596/files
https://github.com/Azure/azure-functions-docker/issues/585

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
