### PR TITLE
add missing jdk version update for v4 appservice images

### DIFF
--- a/host/4/bullseye/amd64/java/java11/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11/java11-composite.template
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=11u7
+ARG JAVA_VERSION=11u11
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0

--- a/host/4/bullseye/amd64/java/java8/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8/java8-composite.template
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=8u252
+ARG JAVA_VERSION=8u292
 
 FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tools as jre
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->


<!-- If you are doing releasing a new host version, please add the release page links of the version -->
Releasing new Host versions.
[V3 Release](PASTE_V3_LINK_HERE)
[V2 Release](PASTE_V2_LINK_HERE)

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [X] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->

When update jdk version from zulu 8u252 to 8u292 and 11u7 to 11u11 in this pr https://github.com/Azure/azure-functions-docker/pull/548, those two files for v4 app-service are missed. This pr update them to the current jdk version used by ant96. 
