### PR TITLE
Optimize DockerFiles for Layer Re-use

### DIFF
--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -2,9 +2,9 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
-COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY sshd_config /etc/ssh/
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -1,14 +1,16 @@
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
-
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -26,8 +28,6 @@ RUN apt-get install -y xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2
     libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
     libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
-COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/dotnet/runtime:5.0
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
-COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY sshd_config /etc/ssh/
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -4,14 +4,17 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS aspnet5
 FROM mcr.microsoft.com/dotnet/runtime:5.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=aspnet5 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 EXPOSE 2222 80
@@ -29,9 +32,6 @@ RUN apt-get install -y xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2
     libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
     libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
     libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
-COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
@@ -4,10 +4,11 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
-COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY sshd_config /etc/ssh/
 
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 

--- a/host/3.0/buster/amd64/java/java11/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11/java11-composite.template
@@ -4,10 +4,11 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/3.0/buster/amd64/java/java11/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11/java11-composite.template
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
-COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY sshd_config /etc/ssh/
 
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 

--- a/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
-COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY sshd_config /etc/ssh/
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
@@ -3,9 +3,9 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 

--- a/host/3.0/buster/amd64/java/java8/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8/java8-composite.template
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
-COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY sshd_config /etc/ssh/
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/3.0/buster/amd64/java/java8/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8/java8-composite.template
@@ -3,9 +3,9 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 

--- a/host/3.0/buster/amd64/node/node10/node10-composite.template
+++ b/host/3.0/buster/amd64/node/node10/node10-composite.template
@@ -1,6 +1,10 @@
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
@@ -21,9 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -32,7 +34,6 @@ RUN apt-get update && \
     echo "root:Docker!" | chpasswd
 
 COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/3.0/buster/amd64/node/node10/node10-composite.template
+++ b/host/3.0/buster/amd64/node/node10/node10-composite.template
@@ -4,6 +4,7 @@ ARG HOST_VERSION
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
@@ -24,8 +25,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
-
-COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node12/node12-composite.template
+++ b/host/3.0/buster/amd64/node/node12/node12-composite.template
@@ -1,6 +1,10 @@
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
     curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
@@ -21,9 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -32,7 +34,6 @@ RUN apt-get update && \
     echo "root:Docker!" | chpasswd
 
 COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/3.0/buster/amd64/node/node12/node12-composite.template
+++ b/host/3.0/buster/amd64/node/node12/node12-composite.template
@@ -4,6 +4,7 @@ ARG HOST_VERSION
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
@@ -24,8 +25,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
-
-COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node14/node14-composite.template
+++ b/host/3.0/buster/amd64/node/node14/node14-composite.template
@@ -1,6 +1,10 @@
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
@@ -21,9 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -32,7 +34,6 @@ RUN apt-get update && \
     echo "root:Docker!" | chpasswd
 
 COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/3.0/buster/amd64/node/node14/node14-composite.template
+++ b/host/3.0/buster/amd64/node/node14/node14-composite.template
@@ -4,6 +4,7 @@ ARG HOST_VERSION
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
@@ -24,8 +25,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
-
-COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node8/node8-composite.template
+++ b/host/3.0/buster/amd64/node/node8/node8-composite.template
@@ -1,6 +1,10 @@
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
@@ -21,9 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -32,7 +34,6 @@ RUN apt-get update && \
     echo "root:Docker!" | chpasswd
 
 COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/3.0/buster/amd64/node/node8/node8-composite.template
+++ b/host/3.0/buster/amd64/node/node8/node8-composite.template
@@ -4,6 +4,7 @@ ARG HOST_VERSION
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
@@ -24,8 +25,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION}
-
-COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 EXPOSE 2222 80
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
@@ -10,9 +15,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
     apt-get install -y libc-dev
-
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -30,9 +32,6 @@ RUN apt-get update && \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
 #    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
-COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -4,6 +4,11 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS aspnet6
 FROM mcr.microsoft.com/dotnet/runtime:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
@@ -14,8 +19,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 RUN apt-get update && \
     apt-get install -y libc-dev
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=aspnet6 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 
 EXPOSE 2222 80
@@ -34,9 +37,6 @@ RUN apt-get update && \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
 #    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
-COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/java/java11-zulu/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11-zulu/java11-composite.template
@@ -4,10 +4,11 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/java/java11/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11/java11-composite.template
@@ -4,10 +4,11 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/java/java8-zulu/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8-zulu/java8-composite.template
@@ -4,10 +4,11 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/java/java8/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8/java8-composite.template
@@ -4,10 +4,11 @@ FROM mcr.microsoft.com/java/jre-headless:${JAVA_VERSION}-zulu-debian10-with-tool
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
 
 EXPOSE 2222 80

--- a/host/4/bullseye/amd64/node/node14/node14-composite.template
+++ b/host/4/bullseye/amd64/node/node14/node14-composite.template
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
@@ -26,9 +31,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 RUN apt-get update && \
     apt-get install -y libc-dev
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -44,9 +47,6 @@ RUN apt-get update && \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
 #    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
-COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/node/node14/node14-composite.template
+++ b/host/4/bullseye/amd64/node/node14/node14-composite.template
@@ -5,6 +5,7 @@ COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
@@ -30,8 +31,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
     apt-get install -y libc-dev
-
-COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 EXPOSE 2222 80
 

--- a/host/4/bullseye/amd64/node/node16/node16-composite.template
+++ b/host/4/bullseye/amd64/node/node16/node16-composite.template
@@ -1,6 +1,11 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.0
 ARG HOST_VERSION
 
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
     curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
@@ -26,9 +31,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 RUN apt-get update && \
     apt-get install -y libc-dev
 
-COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
-COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 
 EXPOSE 2222 80
 
@@ -44,9 +47,6 @@ RUN apt-get update && \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
 #    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
-COPY sshd_config /etc/ssh/
-COPY start.sh /azure-functions-host/
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/node/node16/node16-composite.template
+++ b/host/4/bullseye/amd64/node/node16/node16-composite.template
@@ -5,6 +5,7 @@ COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \
@@ -31,7 +32,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 RUN apt-get update && \
     apt-get install -y libc-dev
 
-COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]
 
 EXPOSE 2222 80
 


### PR DESCRIPTION
Working to capture low hanging fruit to optimize docker layer re-use in platform.  Re-using docker layers makes downloading appservice images faster and cheaper. In this case, I was able to share a larger number of layers between images by moving copy directives.  Putting common Dockerfile portions near the top of our image directives encourages cache re-use for some of our largest layers.  For example, moving FunctionExtensionBundles to the first directive in our appservice images means that most images can share that data. 

The primary reason reducing unique image size is important is to support our image pre-caching step.  When the Linux roles start on platform, they cache several of our most used images.  During startup, they download those images so that when a customer's Function app needs an appservice image it is available without needing to download.  This means that caching images reduces cold start time.  By reducing the size of our docker images, we can cache more images in the space we have allotted and therefore reduce some cold starts. 

There should not be any functional changes to the images in this PR. Re-arranging the directives is all that is needed to benefit cache reuse. 

I built the images before and after implementing these changes to determine the impact.  I have pasted the results below.  One callout on the node 14 images as a representative.  
Unique Image Size
v3 1.212Gb -> 548Mb 55% decrease!
v4 591Mb -> 198.7mb 66% decrease!
![image](https://user-images.githubusercontent.com/46761504/153939548-035b17f3-26b5-49e0-8b21-2a90ec7b4ce4.png)
![image](https://user-images.githubusercontent.com/46761504/153939568-334a4939-fcc6-478c-997b-9d7ee94096a2.png)



![image](https://user-images.githubusercontent.com/46761504/154099721-4276d1aa-1ae2-4423-b193-6c97b3f9b115.png)
![image](https://user-images.githubusercontent.com/46761504/154099830-6ab39d0e-427f-46fb-b744-338856f9a621.png)

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
