### PR TITLE
Enabling environmental variables from SSH - to Dev

### DIFF
--- a/host/3.0/buster/amd64/base/sharedconfig/start.sh
+++ b/host/3.0/buster/amd64/base/sharedconfig/start.sh
@@ -17,6 +17,10 @@ if [ "$APPSVC_REMOTE_DEBUGGING" == "TRUE" ]; then
     export languageWorkers__python__arguments="-m ptvsd --host localhost --port $APPSVC_TUNNEL_PORT"
 fi
 
+# Get environment variables to show up in SSH session
+eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
+
+# starting sshd process
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 
 service ssh start

--- a/host/4/bullseye/amd64/base/sharedconfig/start.sh
+++ b/host/4/bullseye/amd64/base/sharedconfig/start.sh
@@ -17,6 +17,10 @@ if [ "$APPSVC_REMOTE_DEBUGGING" == "TRUE" ]; then
     export languageWorkers__python__arguments="-m ptvsd --host localhost --port $APPSVC_TUNNEL_PORT"
 fi
 
+# Get environment variables to show up in SSH session
+eval $(printenv | sed -n "s/^\([^=]\+\)=\(.*\)$/export \1=\2/p" | sed 's/"/\\\"/g' | sed '/=/s//="/' | sed 's/$/"/' >> /etc/profile)
+
+# starting sshd process
 sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
 
 service ssh start


### PR DESCRIPTION
Copy work item to fix CI for Filipe's PR here : https://github.com/Azure/azure-functions-docker/pull/618

From that 

> The proposed change aims to allow access to the environmental variables of Linux Function App from the SSH console, similar to what is possible on Azure Linux Web Apps.

> The changes are based on startup script found on Linux Web Apps https://github.com/Azure-App-Service/ImageBuilder/blob/master/GenerateDockerFiles/dotnetcore/debian-9/init_container.sh