### PR TITLE
Update Powershell Coretools Pipeline with new powershell folder structure. 

### DIFF
--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-core-tools.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-core-tools.Dockerfile
@@ -12,7 +12,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 ARG PS_VERSION=7.2.1
-ARG PS_PACKAGE=powershell_${PS_VERSION}-1.debian.10_amd64.deb
+ARG PS_PACKAGE=powershell-lts_${PS_VERSION}-1.deb_amd64.deb
 ARG PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 
 # Download the Linux package and save it

--- a/host/4/core-tools-publish.yml
+++ b/host/4/core-tools-publish.yml
@@ -313,6 +313,19 @@ stages:
         continueOnError: false
         env:
           DOCKER_BUILDKIT: 1 
+      - bash: |
+          set -e
+          IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(PrivateVersion)-powershell7.2-core-tools
+
+          docker build -t $IMAGE_NAME \
+                      -f host/4/bullseye/amd64/powershell/powershell72/powershell72-core-tools.Dockerfile \
+                      host/4/bullseye/amd64/powershell/powershell72/
+          npm run test $IMAGE_NAME --prefix  test/
+          docker push $IMAGE_NAME
+        displayName: powershell7.2-core-tools
+        continueOnError: false
+        env:
+          DOCKER_BUILDKIT: 1 
 - stage: publish
   condition: and(not(failed('build')), ne(variables['BuildOnly'], 'true'))
   jobs:
@@ -663,10 +676,13 @@ stages:
       - bash: |
           set -e
           docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-core-tools
+          docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-core-tools
     
           docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-core-tools $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-core-tools
+          docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-core-tools $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-core-tools
                
           docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-core-tools $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7-core-tools
+          docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-core-tools $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7.2-core-tools
 
         displayName: tag powershell images
         continueOnError: false
@@ -674,6 +690,13 @@ stages:
           set -e 
           PrivateImageId=`docker image inspect $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-core-tools --format='{{.Id}}'`
           MajorImageId=`docker image inspect $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7-core-tools --format='{{.Id}}'`
+          if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
+            echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
+            exit 1;
+          fi
+ 
+          PrivateImageId=`docker image inspect $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-core-tools --format='{{.Id}}'`
+          MajorImageId=`docker image inspect $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7.2-core-tools --format='{{.Id}}'`
           if [[ "$PrivateImageId" != "$MajorImageId" ]]; then
             echo "unmatch the Target image id and Major image id ${PrivateImageId} and ${MajorImageId}";
             exit 1;
@@ -691,6 +714,18 @@ stages:
             echo "can not find Az module for powershell7-core-tools. The number of the AzModule is $AZ_MODULE_COUNT"
           fi
 
+          ActualVersion=`docker run $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7.2-core-tools func --version`
+          if [[ "$ActualVersion" != "$(TargetVersion)" ]]; then
+            echo "unmatch the ActualVersion and TargetVersion ${ActualVersion} and $(TargetVersion)";
+            exit 1;
+          fi          
+          docker run $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7.2-core-tools az --version
+
+          AZ_MODULE_COUNT=`docker run $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7.2-core-tools pwsh  -Command "(Get-Module -ListAvailable Az).count"`
+          if [ ! "$AZ_MODULE_COUNT" -gt "0" ]; then
+            echo "can not find Az module for powershell7.2-core-tools. The number of the AzModule is $AZ_MODULE_COUNT"
+          fi
+
         displayName: test powershell images
         continueOnError: false        
       - bash: |
@@ -698,7 +733,11 @@ stages:
           docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-core-tools
 
           docker push $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7-core-tools
-    
+
+          docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-core-tools
+
+          docker push $TARGET_REGISTRY/powershell:$(MajorVersion)-powershell7.2-core-tools
+
           docker system prune -a -f
         displayName: push powershell images
         continueOnError: false

--- a/host/4/core-tools-publish.yml
+++ b/host/4/core-tools-publish.yml
@@ -305,8 +305,8 @@ stages:
           IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(PrivateVersion)-powershell7-core-tools
 
           docker build -t $IMAGE_NAME \
-                      -f host/4/bullseye/amd64/powershell/powershell7-core-tools.Dockerfile \
-                      host/4/bullseye/amd64/powershell/
+                      -f host/4/bullseye/amd64/powershell/powershell70/powershell70-core-tools.Dockerfile \
+                      host/4/bullseye/amd64/powershell/powershell70/
           npm run test $IMAGE_NAME --prefix  test/
           docker push $IMAGE_NAME
         displayName: powershell7-core-tools


### PR DESCRIPTION
Investigated Powershell Core Tools pipeline due to a recent email and found that it was not updated when we introduced Powershell 7.2.  We are not releasing a powershell7.2 core tools image until ant97 finishes rolling out.  But, in the meantime this pipeline needed an updated reference to Powershell 7.0.  

Also fixed the core-tools powershell download link after discussion with @Francisco-Gamino 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
