### PR TITLE
Update powershell minor version tag

### DIFF
--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -50,7 +50,7 @@ steps:
                   host/4/bullseye/amd64/powershell/powershell70
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
-    displayName: powershell70
+    displayName: powershell7
     continueOnError: false
 
   - bash: |
@@ -61,7 +61,7 @@ steps:
                   host/4/bullseye/amd64/powershell/powershell70
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
-    displayName: powershell70-slim
+    displayName: powershell7-slim
     continueOnError: false
 
   - bash: |
@@ -72,39 +72,39 @@ steps:
                   host/4/bullseye/amd64/out/powershell
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
-    displayName: powershell70-appservice
+    displayName: powershell7-appservice
     continueOnError: false
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(Build.SourceBranchName)-powershell72
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(Build.SourceBranchName)-powershell7.2
 
       docker build -t $IMAGE_NAME \
                   -f host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile \
                   host/4/bullseye/amd64/powershell/powershell72
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
-    displayName: powershell72
+    displayName: powershell7.2
     continueOnError: false
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(Build.SourceBranchName)-powershell72-slim
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(Build.SourceBranchName)-powershell7.2-slim
       docker build -t $IMAGE_NAME \
                   -f host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile \
                   host/4/bullseye/amd64/powershell/powershell72
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
-    displayName: powershell72-slim
+    displayName: powershell7.2-slim
     continueOnError: false
 
   - bash: |
       set -e
-      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(Build.SourceBranchName)-powershell72-appservice
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/powershell:$(Build.SourceBranchName)-powershell7.2-appservice
       docker build -t $IMAGE_NAME \
                   -f host/4/bullseye/amd64/out/powershell/powershell72-appservice.Dockerfile \
                   host/4/bullseye/amd64/out/powershell
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
-    displayName: powershell72-appservice
+    displayName: powershell7.2-appservice
     continueOnError: false

--- a/host/4/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/4/publish-appservice-stage-sovereign-clouds.yml
@@ -128,15 +128,15 @@ steps:
       - bash: |
           set -e
           docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice
-          docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice
+          docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice
           
           docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
           docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-$(CloudName)-stage${{stage}}
-          docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice-$(CloudName)-stage${{stage}}
+          docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-$(CloudName)-stage${{stage}}
           
           docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-$(CloudName)-stage${{stage}}
-          docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice-$(CloudName)-stage${{stage}}
+          docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-$(CloudName)-stage${{stage}}
           
           docker system prune -a -f
         displayName: tag and push powershell images for stage ${{stage}}

--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -119,15 +119,15 @@ steps:
   - bash: |
       set -e
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice
+      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice
 
       docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-stage$(StageNumber)
       docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-stage$(StageNumber)
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice-stage$(StageNumber)
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-stage$(StageNumber)
 
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-stage$(StageNumber)
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-stage$(StageNumber)
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice-stage$(StageNumber)
+      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-stage$(StageNumber)
 
       docker system prune -a -f
     displayName: tag and push powershell images

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -240,27 +240,27 @@ steps:
       docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-quickstart
 
       docker system prune -a -f
-    displayName: tag and push powershell 70 images
+    displayName: tag and push powershell 7 images
     continueOnError: false
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-slim
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice
+      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2
+      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-slim
+      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice
 
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72 $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-slim $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-slim
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell72-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2 $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-slim $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-slim
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-quickstart
 
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-slim
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell72-appservice-quickstart
+      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2
+      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-slim
+      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice
+      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-quickstart
 
       docker system prune -a -f
-    displayName: tag and push powershell 72 images
+    displayName: tag and push powershell 7.2 images
     continueOnError: false
 
   - bash: |


### PR DESCRIPTION
Tested platform image selection code path to make sure that support for Powershell 7.2 was enabled. I noticed that platform is pulling from the location below to get the powershell7.2 image.  We are currently releasing images to the tag powershell:4-powershell**72**-appservice.  Blessed images must be published to the location specified by platform for support. 

Platform requests the following: 
`​mcr.microsoft.com/azure-functions/powershell:4-powershell7.2-appservice​` 

This PR updates the powershell versioning for 7.2 for platform support.  It also keeps versioning syntax the same with Python. Which is the other minor versioned language in this repository. 


### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
