### PR TITLE
Set Env Var ASPNET_CONTENTROOT to /azure-functions-host - to limit filewatchers

### DIFF
--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -10,7 +10,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -11,7 +11,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -43,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -43,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -14,7 +14,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=aspnet5 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -13,7 +13,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=aspnet5 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -45,7 +45,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -46,7 +46,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -45,7 +45,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -46,7 +46,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
@@ -18,6 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11-zulu/java11-composite.template
@@ -18,7 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java11/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11/java11-composite.template
@@ -18,6 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java11/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11/java11-composite.template
@@ -18,7 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-tools-11-azure-amd64", "/usr/lib/jvm/zre-11-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -45,7 +45,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -46,7 +46,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -45,7 +45,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -46,7 +46,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
@@ -16,6 +16,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8-zulu/java8-composite.template
@@ -16,7 +16,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java8/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8/java8-composite.template
@@ -16,6 +16,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java8/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8/java8-composite.template
@@ -16,7 +16,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 COPY --from=jre [ "/usr/lib/jvm/zre-hl-8-azure-amd64", "/usr/lib/jvm/zre-8-azure-amd64" ]

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -44,7 +44,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -45,7 +45,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -44,7 +44,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -45,7 +45,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/node/node10/node10-composite.template
+++ b/host/3.0/buster/amd64/node/node10/node10-composite.template
@@ -24,7 +24,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node10/node10-composite.template
+++ b/host/3.0/buster/amd64/node/node10/node10-composite.template
@@ -25,7 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -50,7 +50,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -49,7 +49,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -57,7 +57,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -58,7 +58,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12-composite.template
+++ b/host/3.0/buster/amd64/node/node12/node12-composite.template
@@ -24,7 +24,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node12/node12-composite.template
+++ b/host/3.0/buster/amd64/node/node12/node12-composite.template
@@ -25,7 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -50,7 +50,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -49,7 +49,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -57,7 +57,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -58,7 +58,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14-composite.template
+++ b/host/3.0/buster/amd64/node/node14/node14-composite.template
@@ -24,7 +24,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node14/node14-composite.template
+++ b/host/3.0/buster/amd64/node/node14/node14-composite.template
@@ -25,7 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
@@ -50,7 +50,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
@@ -49,7 +49,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14.Dockerfile
@@ -57,7 +57,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14.Dockerfile
@@ -58,7 +58,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node8/node8-composite.template
+++ b/host/3.0/buster/amd64/node/node8/node8-composite.template
@@ -24,7 +24,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/node/node8/node8-composite.template
+++ b/host/3.0/buster/amd64/node/node8/node8-composite.template
@@ -25,7 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6-composite.template
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6-composite.template
@@ -10,7 +10,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6-composite.template
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6-composite.template
@@ -9,7 +9,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 EXPOSE 2222 80
 

--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6-slim.Dockerfile
@@ -43,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6.Dockerfile
@@ -43,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7-composite.template
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7-composite.template
@@ -8,7 +8,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7-composite.template
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7-composite.template
@@ -7,7 +7,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7-slim.Dockerfile
@@ -47,7 +47,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7-slim.Dockerfile
@@ -48,7 +48,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7.Dockerfile
@@ -47,7 +47,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7.Dockerfile
@@ -48,7 +48,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/python/python36/python36-composite.template
+++ b/host/3.0/buster/amd64/python/python36/python36-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36-composite.template
+++ b/host/3.0/buster/amd64/python/python36/python36-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-composite.template
+++ b/host/3.0/buster/amd64/python/python37/python37-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-composite.template
+++ b/host/3.0/buster/amd64/python/python37/python37-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -47,7 +47,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -48,7 +48,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-composite.template
+++ b/host/3.0/buster/amd64/python/python38/python38-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-composite.template
+++ b/host/3.0/buster/amd64/python/python38/python38-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-composite.template
+++ b/host/3.0/buster/amd64/python/python39/python39-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-composite.template
+++ b/host/3.0/buster/amd64/python/python39/python39-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39.Dockerfile
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -10,7 +10,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -11,7 +11,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -37,7 +37,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -36,7 +36,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -37,7 +37,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -36,7 +36,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -14,7 +14,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -13,7 +13,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -39,7 +39,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -40,7 +40,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -39,7 +39,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -40,7 +40,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java11-zulu/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11-zulu/java11-composite.template
@@ -18,6 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java11-zulu/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11-zulu/java11-composite.template
@@ -18,7 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java11/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11/java11-composite.template
@@ -18,6 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java11/java11-composite.template
+++ b/host/4/bullseye/amd64/java/java11/java11-composite.template
@@ -18,7 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -40,7 +40,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -39,7 +39,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -40,7 +40,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -39,7 +39,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java8-zulu/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8-zulu/java8-composite.template
@@ -18,6 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java8-zulu/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8-zulu/java8-composite.template
@@ -18,7 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java8/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8/java8-composite.template
@@ -18,6 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java8/java8-composite.template
+++ b/host/4/bullseye/amd64/java/java8/java8-composite.template
@@ -18,7 +18,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-8-azure-amd64
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -38,7 +38,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -39,7 +39,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -38,7 +38,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -39,7 +39,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14-composite.template
+++ b/host/4/bullseye/amd64/node/node14/node14-composite.template
@@ -26,7 +26,9 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
+
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14-composite.template
+++ b/host/4/bullseye/amd64/node/node14/node14-composite.template
@@ -27,7 +27,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -43,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -51,7 +51,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -52,7 +52,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-composite.template
+++ b/host/4/bullseye/amd64/node/node16/node16-composite.template
@@ -27,7 +27,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-composite.template
+++ b/host/4/bullseye/amd64/node/node16/node16-composite.template
@@ -26,7 +26,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -43,7 +43,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -51,7 +51,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -52,7 +52,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
@@ -11,7 +11,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
@@ -10,7 +10,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
@@ -44,7 +44,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
@@ -45,7 +45,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
@@ -44,7 +44,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
@@ -45,7 +45,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
@@ -8,7 +8,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=7.2 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
@@ -7,7 +7,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=7.2 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
@@ -42,7 +42,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=7.2 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
@@ -41,7 +41,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=7.2 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
@@ -42,7 +42,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME_VERSION=7.2 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
@@ -41,7 +41,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=7.2 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python37/python37-composite.template
+++ b/host/4/bullseye/amd64/python/python37/python37-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python37/python37-composite.template
+++ b/host/4/bullseye/amd64/python/python37/python37-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
@@ -40,7 +40,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
@@ -41,7 +41,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -40,7 +40,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -41,7 +41,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python38/python38-composite.template
+++ b/host/4/bullseye/amd64/python/python38/python38-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python38/python38-composite.template
+++ b/host/4/bullseye/amd64/python/python38/python38-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
@@ -40,7 +40,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
@@ -41,7 +41,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -40,7 +40,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -41,7 +41,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python39/python39-composite.template
+++ b/host/4/bullseye/amd64/python/python39/python39-composite.template
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python39/python39-composite.template
+++ b/host/4/bullseye/amd64/python/python39/python39-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
@@ -40,7 +40,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
@@ -41,7 +41,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -40,7 +40,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_ContentRoot=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -41,7 +41,7 @@ ENV LANG=C.UTF-8 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_ContentRoot=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Related to recent issue https://github.com/Azure/azure-functions-docker/issues/628

Update all images to add the ASPNET_CONTENTROOT variable to the environment.  This PR incorporates the changes introduced by hotfix releases 
https://github.com/Azure/azure-functions-docker/releases/tag/4.1.3.1
https://github.com/Azure/azure-functions-docker/releases/tag/3.4.2.1


A recent incident found that the Azure-Functions-Host spawned a very high number of inotify filewatchers on startup.  The cause was found to be a WebHostBuilder object in the Functions-Host code. The object [inherits ASPNET_CONTENTROOT as its context](https://github.com/aspnet/MetaPackages/blob/master/src/Microsoft.AspNetCore/WebHost.cs#L152).  Without that environment variable set, the object defaults to the `current directory` which is currently `/` for the linux images. 

This PR provides `ASPNET_CONTENTROOT = /azure-functions-host` to the WebHostBuilder which decreases the number of inotify filewatchers spawned on startup significantly.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
