### PR TITLE
Set Env Var ASPNET_CONTENTROOT to /azure-functions-host in V3 Images

### DIFF
--- a/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -60,7 +60,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=false \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN rm /usr/bin/qemu-arm-static
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -5,7 +5,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-appservice.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -8,7 +8,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/3.0/buster/amd64/java/java11/java11-composite.template
+++ b/host/3.0/buster/amd64/java/java11/java11-composite.template
@@ -11,6 +11,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=/usr/lib/jvm/zre-11-azure-amd64
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -45,7 +45,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -45,7 +45,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8/java8-composite.template
+++ b/host/3.0/buster/amd64/java/java8/java8-composite.template
@@ -9,7 +9,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -44,7 +44,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -44,7 +44,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=java \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]

--- a/host/3.0/buster/amd64/node/node10/node10-composite.template
+++ b/host/3.0/buster/amd64/node/node10/node10-composite.template
@@ -19,7 +19,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -49,7 +49,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -57,7 +57,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12-composite.template
+++ b/host/3.0/buster/amd64/node/node12/node12-composite.template
@@ -19,7 +19,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -49,7 +49,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -57,7 +57,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14-composite.template
+++ b/host/3.0/buster/amd64/node/node14/node14-composite.template
@@ -19,7 +19,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
@@ -49,7 +49,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node14/node14.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14.Dockerfile
@@ -57,7 +57,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/node/node8/node8-composite.template
+++ b/host/3.0/buster/amd64/node/node8/node8-composite.template
@@ -19,7 +19,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=node \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node" ]

--- a/host/3.0/buster/amd64/powershell/powershell6-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-appservice.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell6-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6-slim.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell6.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell6.Dockerfile
@@ -42,7 +42,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \

--- a/host/3.0/buster/amd64/powershell/powershell7-appservice.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7-appservice.Dockerfile
@@ -47,7 +47,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7-slim.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7-slim.Dockerfile
@@ -47,7 +47,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/powershell/powershell7.Dockerfile
+++ b/host/3.0/buster/amd64/powershell/powershell7.Dockerfile
@@ -47,7 +47,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=powershell \
     FUNCTIONS_WORKER_RUNTIME_VERSION=~7 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]

--- a/host/3.0/buster/amd64/python/python36/python36-composite.template
+++ b/host/3.0/buster/amd64/python/python36/python36-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-composite.template
+++ b/host/3.0/buster/amd64/python/python37/python37-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -47,7 +47,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-composite.template
+++ b/host/3.0/buster/amd64/python/python38/python38-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-composite.template
+++ b/host/3.0/buster/amd64/python/python39/python39-composite.template
@@ -9,7 +9,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39.Dockerfile
@@ -46,7 +46,8 @@ ENV LANG=C.UTF-8 \
     ASPNETCORE_URLS=http://+:80 \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 # Install Python dependencies
 RUN apt-get update && \

--- a/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
@@ -59,7 +59,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
     FUNCTIONS_WORKER_RUNTIME=dotnet \
     DOTNET_USE_POLLING_FILE_WATCHER=false \
-    HOST_VERSION=${HOST_VERSION}
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
 
 RUN rm /usr/bin/qemu-arm-static
 


### PR DESCRIPTION
Related to recent issue https://github.com/Azure/azure-functions-docker/issues/628

Update the latest version of the v3 images (3.4.2) to add the ASPNET_CONTENTROOT variable to the environment. 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
