### PR TITLE
Disable PowerShell tests

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -195,8 +195,10 @@ async function main() {
     await runTest(testData.node, "-e FUNCTIONS_WORKER_RUNTIME=node");
     await runTest(testData.python, "-e FUNCTIONS_WORKER_RUNTIME=python");
     await runTest(testData.java, "-e FUNCTIONS_WORKER_RUNTIME=java");
-    await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell -e FUNCTIONS_WORKER_RUNTIME_VERSION=7");
-    await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell -e FUNCTIONS_WORKER_RUNTIME_VERSION=7.2");
+
+    // Enable PowerShell tests for V4 only - https://github.com/Azure/azure-functions-docker/issues/640
+    // await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell -e FUNCTIONS_WORKER_RUNTIME_VERSION=7");
+    // await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell -e FUNCTIONS_WORKER_RUNTIME_VERSION=7.2");
   }
 }
 


### PR DESCRIPTION
Disabling the PowerShell tests to unblock the build.

Update PowerShell tests to only run on V4 (https://github.com/Azure/azure-functions-docker/issues/640).