### PR TITLE
[DNM] Removing Worker Runtime Version from Powershell Tests

### DIFF
--- a/host/3.0/buster/amd64/powershell/powershell6/powershell6-composite.template
+++ b/host/3.0/buster/amd64/powershell/powershell6/powershell6-composite.template
@@ -11,7 +11,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host
-
+# Providing comment to trigger build
 EXPOSE 2222 80
 
 RUN apt-get update && \

--- a/host/3.0/buster/amd64/powershell/powershell7/powershell7-composite.template
+++ b/host/3.0/buster/amd64/powershell/powershell7/powershell7-composite.template
@@ -9,7 +9,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host
-
+# Providing comment to trigger build
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
@@ -16,7 +16,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
     apt-get install -y libc-dev
-
+# Providing comment to trigger build
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
@@ -9,7 +9,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host
-
+# Providing comment to trigger build
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
     apt-get install -y libc-dev

--- a/test/index.ts
+++ b/test/index.ts
@@ -195,13 +195,7 @@ async function main() {
     await runTest(testData.node, "-e FUNCTIONS_WORKER_RUNTIME=node");
     await runTest(testData.python, "-e FUNCTIONS_WORKER_RUNTIME=python");
     await runTest(testData.java, "-e FUNCTIONS_WORKER_RUNTIME=java");
-    await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell -e FUNCTIONS_WORKER_RUNTIME_VERSION=7");
-
-    // PowerShell 7.2 is only supported in Functions V4.
-    // If image name contains '/4/' in the path, run the PowerShell 7.2 tests
-    if (imageName.includes("/4/")) {
-      await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell -e FUNCTIONS_WORKER_RUNTIME_VERSION=7.2");
-    }
+    await runTest(testData.powershell, "-e FUNCTIONS_WORKER_RUNTIME=powershell");
   }
 }
 


### PR DESCRIPTION
As a result of a recent PR that added Powershell 7.2 tests to CI, I noticed that we do not provide the Worker Runtime Language Version to any of the other languages present in this repo. I am testing removing the runtime version to keep all the tests consistent. DNM 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
