### PR TITLE
Move Java Build images to the Dotnet SDK base image

### DIFF
--- a/host/3.0/buster/amd64/java/java11/java11-build.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-build.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 ARG MAVEN_VERSION=3.8.5
 ARG USER_HOME_DIR="/root"

--- a/host/3.0/buster/amd64/java/java8/java8-build.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-build.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 ARG MAVEN_VERSION=3.8.5
 ARG USER_HOME_DIR="/root"

--- a/host/4/bullseye/amd64/java/java11/java11-build.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-build.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM mcr.microsoft.com/dotnet/sdk:6.0 
 
 ARG MAVEN_VERSION=3.8.5
 ARG USER_HOME_DIR="/root"

--- a/host/4/bullseye/amd64/java/java8/java8-build.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-build.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM mcr.microsoft.com/dotnet/sdk:6.0 
 
 ARG MAVEN_VERSION=3.8.5
 ARG USER_HOME_DIR="/root"


### PR DESCRIPTION
Java build images were based on a raw debian image.  We want to avoid outside dependencies to remain compliant with security scanners that run during CI.  This PR moves the images to an in house dotnet sdk image.  

There is no reason for the dotnet dependencies within these images.  

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
