### PR TITLE
fix: Core-Tools CI fails by PowerShell image build

### DIFF
--- a/host/3.0/core-tools-publish.yml
+++ b/host/3.0/core-tools-publish.yml
@@ -305,8 +305,8 @@ stages:
           IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/powershell:$(PrivateVersion)-powershell6-core-tools
 
           docker build -t $IMAGE_NAME \
-                      -f host/3.0/buster/amd64/powershell/powershell6-core-tools.Dockerfile \
-                      host/3.0/buster/amd64/powershell/
+                      -f host/3.0/buster/amd64/powershell/powershell6/powershell6-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/powershell/powershell6/
           npm run test $IMAGE_NAME --prefix  test/
           docker push $IMAGE_NAME
         displayName: powershell6-core-tools
@@ -318,8 +318,8 @@ stages:
           IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/3.0/powershell:$(PrivateVersion)-powershell7-core-tools
 
           docker build -t $IMAGE_NAME \
-                      -f host/3.0/buster/amd64/powershell/powershell7-core-tools.Dockerfile \
-                      host/3.0/buster/amd64/powershell/
+                      -f host/3.0/buster/amd64/powershell/powershell7/powershell7-core-tools.Dockerfile \
+                      host/3.0/buster/amd64/powershell/powershell7/
           npm run test $IMAGE_NAME --prefix  test/
           docker push $IMAGE_NAME
         displayName: powershell7-core-tools


### PR DESCRIPTION
Core Tools publish CI has been fail. 
https://azure-functions.visualstudio.com/azure-functions-docker/_build/results?buildId=15071&view=logs&j=73f01dec-67da-5025-3a59-6c08056acec7&t=4ddcf9fa-0b3a-5aeb-e4cb-33d73590d36f

The root cause was, the directory structure change. 
I fix it by fitting the current structure. 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
