### PR TITLE
Update Dotnet5 sdk for Nanoserver 1809 images

### DIFF
--- a/host/3.0/nanoserver/1809/dotnet.Dockerfile
+++ b/host/3.0/nanoserver/1809/dotnet.Dockerfile
@@ -6,9 +6,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019 AS installer-env
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Retrieve .NET Core SDK
-RUN $dotnet_sdk_version = '5.0.404'; `
+RUN $dotnet_sdk_version = '5.0.408'; `
     Invoke-WebRequest -OutFile dotnet.zip https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-win-x64.zip; `
-    $dotnet_sha512 = 'a6d254a46e93a41bf41df34c941503cfc5f61af20ffc0abc571bbaf238fd66f0fcc879e7181e1e1af788e96912b31012e817bf1202e55b8f27c17352f3f5528d'; `
+    $dotnet_sha512 = '3845485401695b325d9afee67e33c6b3a45902476e408dd74ebc8815ad2c4f4b5d70a6b993e87ff587d0d9b0e5a3d66eaf3dd6bf715b0012ffee70501a716485'; `
     if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $dotnet_sha512) { `
         Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
         exit 1; `


### PR DESCRIPTION
Periodic manual update of the dotnet5 sdk for the Windows image that we produce.  Hoping to automate this soon by relying on a base image FROM dotnet-docker with the dotnet 5 sdk.  Unsure how I would test that, so for now manual updates are required to keep the dotnet sdk in line with the latest release. 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
