### PR TITLE
Removing patch version from the dotnet runtime and aspnet images

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -1,7 +1,7 @@
 # Include ASP.NET Core shared framework from dotnet/aspnet image.
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS aspnet6
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 ARG HOST_VERSION
 
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
 # Include ASP.NET Core shared framework from dotnet/aspnet image.
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS aspnet6
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
 # Include ASP.NET Core shared framework from dotnet/aspnet image.
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS aspnet6
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 ARG HOST_VERSION
 
 # Powershell worker requires 3.1 for now

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 ARG HOST_VERSION
 
 # set runtime env variables

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 ARG HOST_VERSION
 
 # set runtime env variables

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
     find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
 ARG HOST_VERSION
 
 # set runtime env variables


### PR DESCRIPTION
This is a follow up PR to #686 in which the patch version part was removed from the dotnet images we use in our docker images. I noticed we have a few more entries still left which uses the patch version. So fixing them.

In this PR, I am changing:
 * mcr.microsoft.com/dotnet/runtime:**6.0.0** _to_ mcr.microsoft.com/dotnet/runtime:**6.0**
 * mcr.microsoft.com/dotnet/aspnet:**6.0.0**-bullseye-slim _to_ mcr.microsoft.com/dotnet/aspnet:**6.0**-bullseye-slim

Before the change.

![image](https://user-images.githubusercontent.com/144469/174645532-17afb716-e1fd-4cca-a412-c861cb7313ea.png)

After the change

![image](https://user-images.githubusercontent.com/144469/174645715-8642b8f5-4cda-4856-ba8e-12cbe3f9900d.png)

Size different between images(before fix & after fix)
![image](https://user-images.githubusercontent.com/144469/174645885-5ffdc375-b73a-4546-9aa9-ad9d2284ca24.png)

cc @pragnagopa 
