### PR TITLE
Update 4.6.1 release with Dotnet7-isolated images. 

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-composite.template
@@ -1,0 +1,44 @@
+# Include ASP.NET Core shared framework from dotnet/aspnet image.
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:7.0 AS aspnet7
+
+FROM mcr.microsoft.com/dotnet/nightly/runtime:7.0
+ARG HOST_VERSION
+
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY sshd_config /etc/ssh/
+COPY start.sh /azure-functions-host/
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
+
+# Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
+RUN apt-get update && \
+    apt-get install -y libc-dev
+
+COPY --from=aspnet7 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
+
+EXPOSE 2222 80
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gnupg wget unzip curl dialog openssh-server && \
+    # Add remote dotnet debugger
+    curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v vs2017u5 -l /root/vsdbg && \
+    echo "root:Docker!" | chpasswd
+
+# This is current not working with the .NET 6.0 image based on bullseye. Tracking here: https://github.com/Azure/azure-functions-docker/issues/451
+# Chrome headless dependencies
+# https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
+# RUN apt-get install -y xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
+#    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+#    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+#    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
+#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+RUN chmod +x /azure-functions-host/start.sh
+
+ENTRYPOINT ["/azure-functions-host/start.sh"]

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,0 +1,55 @@
+# Build the runtime from source
+ARG HOST_VERSION=4.6.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
+ARG HOST_VERSION
+
+ENV PublishWithAspNetCoreTargetManifest=false
+
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+    cd /src/azure-functions-host && \
+    HOST_COMMIT=$(git rev-list -1 HEAD) && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
+    rm -rf /root/.local /root/.nuget /src
+
+RUN apt-get update && \
+    apt-get install -y gnupg wget unzip && \
+    EXTENSION_BUNDLE_VERSION_V2=2.13.0 && \
+    EXTENSION_BUNDLE_FILENAME_V2=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V2}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/$EXTENSION_BUNDLE_FILENAME_V2 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
+    EXTENSION_BUNDLE_VERSION_V3=3.11.0 && \
+    EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V3 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
+    find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
+
+# Include ASP.NET Core shared framework from dotnet/aspnet image.
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:7.0 AS aspnet7
+
+FROM mcr.microsoft.com/dotnet/nightly/runtime:7.0
+ARG HOST_VERSION
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
+
+# Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
+RUN apt-get update && \
+    apt-get install -y libc-dev
+
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+
+COPY --from=aspnet7 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
+
+CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile
@@ -1,0 +1,53 @@
+# Build the runtime from source
+ARG HOST_VERSION=4.6.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
+ARG HOST_VERSION
+
+ENV PublishWithAspNetCoreTargetManifest=false
+
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+    cd /src/azure-functions-host && \
+    HOST_COMMIT=$(git rev-list -1 HEAD) && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
+    rm -rf /root/.local /root/.nuget /src
+
+RUN apt-get update && \
+    apt-get install -y gnupg wget unzip && \
+    EXTENSION_BUNDLE_VERSION_V2=2.13.0 && \
+    EXTENSION_BUNDLE_FILENAME_V2=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V2}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/$EXTENSION_BUNDLE_FILENAME_V2 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
+    EXTENSION_BUNDLE_VERSION_V3=3.11.0 && \
+    EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V3 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
+    find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
+
+# Include ASP.NET Core shared framework from dotnet/aspnet image.
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:7.0 AS aspnet7
+
+FROM mcr.microsoft.com/dotnet/nightly/runtime:7.0
+ARG HOST_VERSION
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
+
+# Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
+RUN apt-get update && \
+    apt-get install -y libc-dev
+
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+COPY --from=aspnet7 [ "/usr/share/dotnet", "/usr/share/dotnet" ]
+
+CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/sshd_config
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/sshd_config
@@ -1,0 +1,15 @@
+# This is ssh server systemwide configuration file.
+#
+# /etc/sshd_config
+
+Port 			SSH_PORT
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/start.sh
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+export DOTNET_USE_POLLING_FILE_WATCHER=true
+
+if [ -z $PORT ]; then
+  export ASPNETCORE_URLS=http://*:80
+else
+  export ASPNETCORE_URLS=http://*:$PORT
+fi
+
+if [ -z $SSH_PORT ]; then
+  export SSH_PORT=2222
+fi
+
+if [ "$APPSVC_REMOTE_DEBUGGING" == "TRUE" ]; then
+    export languageWorkers__node__arguments="--inspect=0.0.0.0:$APPSVC_TUNNEL_PORT"
+    export languageWorkers__python__arguments="-m ptvsd --host localhost --port $APPSVC_TUNNEL_PORT"
+fi
+
+sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
+
+service ssh start
+
+if [ -f /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost ]; then
+    /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost
+else
+    dotnet /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll
+fi

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -128,6 +128,48 @@ steps:
     displayName: dotnet-isolated-appservice (.NET 6)
     continueOnError: false
 
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet-isolated:$(Build.SourceBranchName)-dotnet-isolated7.0
+      IMAGE_ARRAY="$(image_list),$IMAGE_NAME"
+      echo "##vso[task.setvariable variable=image_list;]$IMAGE_ARRAY"
+
+      docker build -t $IMAGE_NAME \
+                  -f host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile \
+                  host/4/bullseye/amd64/dotnet/dotnet7-isolated/
+      npm run test $IMAGE_NAME --prefix test/
+      docker push $IMAGE_NAME
+    displayName: dotnet-isolated (.NET 7 Preview)
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet-isolated:$(Build.SourceBranchName)-dotnet-isolated7.0-slim
+      IMAGE_ARRAY="$(image_list),$IMAGE_NAME"
+      echo "##vso[task.setvariable variable=image_list;]$IMAGE_ARRAY"
+
+      docker build -t $IMAGE_NAME \
+                  -f host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile \
+                  host/4/bullseye/amd64/dotnet/dotnet7-isolated/
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: dotnet-isolated-slim (.NET 7 Preview)
+    continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet-isolated:$(Build.SourceBranchName)-dotnet-isolated7.0-appservice
+      IMAGE_ARRAY="$(image_list),$IMAGE_NAME"
+      echo "##vso[task.setvariable variable=image_list;]$IMAGE_ARRAY"
+
+      docker build -t $IMAGE_NAME \
+                  -f host/4/bullseye/amd64/out/dotnet/dotnet7-isolated-appservice.Dockerfile \
+                  host/4/bullseye/amd64/out/dotnet/
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: dotnet-isolated-appservice (.NET 7 Preview)
+    continueOnError: false
+
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Manifest Generator'
     inputs:

--- a/host/4/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/4/publish-appservice-stage-sovereign-clouds.yml
@@ -76,6 +76,18 @@ steps:
 
       - bash: |
           set -e
+          docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice
+          
+          docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice-$(CloudName)-stage${{stage}}
+          
+          docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice-$(CloudName)-stage${{stage}}
+          
+          docker system prune -a -f
+        displayName: tag and push dotnet-isolated7 images for stage ${{stage}}
+        continueOnError: false
+
+      - bash: |
+          set -e
           docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice
           docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8.1-appservice
           docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice

--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -67,6 +67,18 @@ steps:
 
   - bash: |
       set -e
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice
+
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice-stage$(StageNumber)
+
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice-stage$(StageNumber)
+
+      docker system prune -a -f
+    displayName: tag and push dotnet-isolated7 images
+    continueOnError: false
+
+  - bash: |
+      set -e
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8.1-appservice
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11-appservice

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -90,6 +90,26 @@ steps:
     displayName: tag and push dotnet-isolated images
     continueOnError: false
 
+  - bash: |
+      set -e
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-slim
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice
+
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0 $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-slim $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-slim
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated7.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-slim
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated7.0-appservice-quickstart
+
+      docker system prune -a -f
+    displayName: tag and push dotnet7-isolated images
+    continueOnError: false
+
 
   - bash: |
       set -e

--- a/test/index.ts
+++ b/test/index.ts
@@ -23,6 +23,12 @@ const dotnetIsolated6 = {
   response: "Hello, Test"
 }
 
+const dotnetIsolated7 = {
+  package: `${storagePath}/dotnet-isolated7-functions.zip`,
+  invoke: "/api/DotnetIsolated7HttpFunction",
+  response: "Welcome to Azure Functions! .NET 7 Preview 5"
+}
+
 const map = {
   python: {
     package: `${storagePath}/python-functions.zip`,
@@ -60,6 +66,7 @@ const testData = (function() {
   else if (imageName.indexOf("node") !== -1) return map.node;
   else if (imageName.indexOf("dotnet-isolated5.0") !== -1) return dotnetIsolated5;
   else if (imageName.indexOf("dotnet-isolated6.0") !== -1) return dotnetIsolated6;
+  else if (imageName.indexOf("dotnet-isolated7.0") !== -1) return dotnetIsolated7;
   else if (imageName.indexOf("mesh") !== -1) return map;
   else return map.dotnet;
 })();


### PR DESCRIPTION
Preparing a hotfix for version 4.6.1 to include Dotnet7-isoalted images and quickly deploy them to all available UD zones.

Release/4.x-hotfix has not been updated since 4.5.2. But, if you compare this branch to the 4.6.1 release tag you will see that the only change is the dotnet7 commit Shyju introduced.