### PR TITLE
Update LibAppIndicator in V4 to libayatana-appindicator

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-composite.template
@@ -32,7 +32,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -37,7 +37,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-composite.template
@@ -37,7 +37,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/node/node14/node14-composite.template
+++ b/host/4/bullseye/amd64/node/node14/node14-composite.template
@@ -20,7 +20,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
@@ -47,7 +47,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \

--- a/host/4/bullseye/amd64/node/node16/node16-composite.template
+++ b/host/4/bullseye/amd64/node/node16/node16-composite.template
@@ -20,7 +20,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \
@@ -47,7 +47,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 RUN chmod +x /azure-functions-host/start.sh
 

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOME=/home \

--- a/host/4/bullseye/amd64/python/python37/python37-composite.template
+++ b/host/4/bullseye/amd64/python/python37/python37-composite.template
@@ -72,7 +72,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -89,7 +89,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image [ "/workers/python/3.7/LINUX", "/azure-functions-host/workers/python/3.7/LINUX" ]

--- a/host/4/bullseye/amd64/python/python38/python38-composite.template
+++ b/host/4/bullseye/amd64/python/python38/python38-composite.template
@@ -72,7 +72,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -89,7 +89,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image [ "/workers/python/3.8/LINUX", "/azure-functions-host/workers/python/3.8/LINUX" ]

--- a/host/4/bullseye/amd64/python/python39/python39-composite.template
+++ b/host/4/bullseye/amd64/python/python39/python39-composite.template
@@ -72,7 +72,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -89,7 +89,7 @@ RUN apt-get update && \
 #    libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 #    libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
 #    libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
-#    libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+#    libxtst6 ca-certificates fonts-liberation libayatana-appindicator3-1 libnss3 lsb-release xdg-utils wget
 
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image [ "/workers/python/3.9/LINUX", "/azure-functions-host/workers/python/3.9/LINUX" ]


### PR DESCRIPTION
https://github.com/Azure/azure-functions-docker/issues/333 identified that LibAppIndicator is deprecated in Bullseye Debian and needs to be replaced with a supported library.  This library needs to be updated to support Chrome Headless.

This PR is building off of the work of @nyds https://github.com/Azure/azure-functions-docker/pull/738/files
Link to Debian Bug Discussion : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037


---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
