### PR TITLE
Pausing Python 3.6 Releases

### DIFF
--- a/host/3.0/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/3.0/publish-appservice-stage-sovereign-clouds.yml
@@ -140,19 +140,20 @@ steps:
 
       - bash: |
           set -e
-          docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
+          # INFO 07/27/2022 - Commenting all Python 3.6 releases until we can hotfix 3.12.1.
+          # docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
           docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice
           docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice
           docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice
 
-          docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
-          docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-$(CloudName)-stage${{stage}}
+          # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
+          # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-$(CloudName)-stage${{stage}}
           docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-$(CloudName)-stage${{stage}}
           docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-$(CloudName)-stage${{stage}}
           docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-$(CloudName)-stage${{stage}}
 
           docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
-          docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-$(CloudName)-stage${{stage}}
+          # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-$(CloudName)-stage${{stage}}

--- a/host/3.0/publish-appservice-stage.yml
+++ b/host/3.0/publish-appservice-stage.yml
@@ -131,19 +131,20 @@ steps:
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
+      # INFO 07/27/2022 - Commenting all Python 3.6 releases until we can hotfix 3.12.1.
+      # docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice
 
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-stage$(StageNumber)
-      docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-stage$(StageNumber)
+      # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-stage$(StageNumber)
+      # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-stage$(StageNumber)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-stage$(StageNumber)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-stage$(StageNumber)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-stage$(StageNumber)
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-stage$(StageNumber)
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-stage$(StageNumber)
+      # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-stage$(StageNumber)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-stage$(StageNumber)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-stage$(StageNumber)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-stage$(StageNumber)

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -312,11 +312,12 @@ stages:
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
 
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-slim
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-quickstart
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-buildenv
+        # INFO 07/27/2022 - Commenting all Python 3.6 releases until we can hotfix 3.12.1.
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-slim
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-quickstart
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-buildenv
 
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-slim


### PR DESCRIPTION
We're pausing the release of Python 3.6 images to new stages until we can determine a hotfix. This PR temporarily removes the release of Python 3.6.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
