### PR TITLE
Removing push of appservice image (#751)

### DIFF
--- a/host/3.0/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/3.0/publish-appservice-stage-sovereign-clouds.yml
@@ -152,7 +152,7 @@ steps:
           docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-$(CloudName)-stage${{stage}}
           docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-$(CloudName)-stage${{stage}}
 
-          docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
+          # docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
           # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-$(CloudName)-stage${{stage}}

--- a/host/3.0/publish-appservice-stage.yml
+++ b/host/3.0/publish-appservice-stage.yml
@@ -143,7 +143,7 @@ steps:
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-stage$(StageNumber)
       docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-stage$(StageNumber)
 
-      docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-stage$(StageNumber)
+      # docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-stage$(StageNumber)
       # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-stage$(StageNumber)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-appservice-stage$(StageNumber)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.8-appservice-stage$(StageNumber)

--- a/host/3.0/publish.yml
+++ b/host/3.0/publish.yml
@@ -259,10 +259,10 @@ stages:
 
     - bash: |
         set -e
-        docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6
-        docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim
-        docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
-        docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv
+        # docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6
+        # docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim
+        # docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice
+        # docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice
@@ -276,17 +276,17 @@ stages:
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-buildenv
 
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-slim
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
 
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)-python3.6
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-slim
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-quickstart
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-buildenv
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6 $TARGET_REGISTRY/python:$(TargetVersion)-python3.6
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-slim
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-appservice-quickstart
+        # docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.6-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.6-buildenv
 
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7 $TARGET_REGISTRY/python:$(TargetVersion)-python3.7
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-slim
@@ -306,11 +306,11 @@ stages:
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-appservice-quickstart
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.9-buildenv
 
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice-quickstart
+        # docker push $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
 
         # INFO 07/27/2022 - Commenting all Python 3.6 releases until we can hotfix 3.12.1.
         # docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.6


### PR DESCRIPTION
* Removing push of appservice image
* Removing all associated commands
* Removing reference to non-versioned python that will fail

This prior [PR ](https://github.com/Azure/azure-functions-docker/pull/745) missed commenting two pushes that will fail once we try to release. This PR aims to correct that.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.