### PR TITLE
HOTFIX - Manually update images to Host Version 4.11.3

### DIFF
--- a/host/4/bullseye/amd64/base/host.Dockerfile
+++ b/host/4/bullseye/amd64/base/host.Dockerfile
@@ -1,4 +1,4 @@
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 ARG JAVA_VERSION=11.0.13.8.1
 ARG JAVA_HOME=/usr/lib/jvm/msft-11-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/amd64/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/amd64/java/java11/java11.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 ARG JAVA_VERSION=11.0.13.8.1
 ARG JAVA_HOME=/usr/lib/jvm/msft-11-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/amd64/java/java17/java17-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java17/java17-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 ARG JAVA_VERSION=17.0.3
 ARG JAVA_HOME=/usr/lib/jvm/msft-17-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/amd64/java/java17/java17.Dockerfile
+++ b/host/4/bullseye/amd64/java/java17/java17.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 ARG JAVA_VERSION=17.0.3
 ARG JAVA_HOME=/usr/lib/jvm/msft-17-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 ARG JAVA_VERSION=8u312b07
 ARG JDK_NAME=jdk8u312-b07
 ARG JAVA_HOME=/usr/lib/jvm/adoptium-8-x64

--- a/host/4/bullseye/amd64/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/amd64/java/java8/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 ARG JAVA_VERSION=8u312b07
 ARG JDK_NAME=jdk8u312-b07
 ARG JAVA_HOME=/usr/lib/jvm/adoptium-8-x64

--- a/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/amd64/node/node14/node14.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/amd64/node/node16/node16.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/node/node18/node18-slim.Dockerfile
+++ b/host/4/bullseye/amd64/node/node18/node18-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/node/node18/node18.Dockerfile
+++ b/host/4/bullseye/amd64/node/node18/node18.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python310/python310-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python310/python310-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python310/python310.Dockerfile
+++ b/host/4/bullseye/amd64/python/python310/python310.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.11.2
+ARG HOST_VERSION=4.11.3
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - release/4.x
+      - release/4.*
       - refresh/4.*
   paths:
     include:

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -21,7 +21,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - release/4.x
+      - release/4.*
       - refresh/4.*
   paths:
     include:

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - release/4.x
+      - release/4.*
       - refresh/4.*
   paths:
     include:

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -18,7 +18,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - release/4.x
+      - release/4.*
       - refresh/4.*
   paths:
     include:

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - release/4.x
+      - release/4.*
       - refresh/4.*
   paths:
     include:


### PR DESCRIPTION
Update Docker Images with Host Version 4.11.3. Hotfix release these images to stage 4 today. 

This release will mitigate an emerging issue on Linux Dedicated and Elastic Premium Function Apps related to logging Function Execution Counts. 