### PR TITLE
Nightly Rebuild pipelines for V4

### DIFF
--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -15,20 +15,11 @@ pr:
 trigger:
   branches:
     include:
-      - nightly-build
-      - refresh/4.*
-
-trigger:
-  branches:
-    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-  paths:
-    include:
-      - host/4/bullseye/amd64/base/*
-      - host/4/bullseye/amd64/dotnet/*
-      - host/4/dotnet-build.yml
+      - nightly-build
+      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -15,10 +15,15 @@ pr:
 trigger:
   branches:
     include:
+      - nightly-build
+      - refresh/4.*
+
+trigger:
+  branches:
+    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-      - refresh/4.*
   paths:
     include:
       - host/4/bullseye/amd64/base/*

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -19,10 +19,15 @@ pr:
 trigger:
   branches:
     include:
+      - nightly-build
+      - refresh/4.*
+
+trigger:
+  branches:
+    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-      - refresh/4.*
   paths:
     include:
       - host/4/bullseye/amd64/base/*

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -19,24 +19,11 @@ pr:
 trigger:
   branches:
     include:
-      - nightly-build
-      - refresh/4.*
-
-trigger:
-  branches:
-    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-  paths:
-    include:
-      - host/4/bullseye/amd64/base/*
-      - host/4/bullseye/amd64/java/java8/*
-      - host/4/bullseye/amd64/java/java8-zulu/*
-      - host/4/bullseye/amd64/java/java11/*
-      - host/4/bullseye/amd64/java/java11-zulu/*
-      - host/4/bullseye/amd64/java/java17/*
-      - host/4/java-build.yml
+      - nightly-build
+      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/nightly-build.yml
+++ b/host/4/nightly-build.yml
@@ -1,0 +1,30 @@
+name: Nightly-Build
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - dev
+  always: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Dev Branch
+      uses: actions/checkout@v2
+      with:
+        ref: dev
+        fetch-depth: 0
+        token: ${{ secrets.PIPELINE_ADMIN }}
+    - name: Update Nightly with Latest Dev
+      id: createBranch
+      run: |
+        set -e
+        git config --local user.email "azfuncgh@github.com"
+        git config --local user.name "Azure Functions"
+        git fetch --all
+        git checkout -b  nightly-build origin/nightly-build
+        git merge dev
+        git push origin nightly-build
+      env:
+        GITHUB_TOKEN: ${{ secrets.PIPELINE_ADMIN }}

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -15,20 +15,11 @@ pr:
 trigger:
   branches:
     include:
-      - nightly-build
-      - refresh/4.*
-
-trigger:
-  branches:
-    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-  paths:
-    include:
-      - host/4/bullseye/amd64/base/*
-      - host/4/bullseye/amd64/node/*
-      - host/4/node-build.yml
+      - nightly-build
+      - refresh/4.*
 
 steps:
   - bash: |

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -15,10 +15,15 @@ pr:
 trigger:
   branches:
     include:
+      - nightly-build
+      - refresh/4.*
+
+trigger:
+  branches:
+    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-      - refresh/4.*
   paths:
     include:
       - host/4/bullseye/amd64/base/*

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -16,21 +16,11 @@ pr:
 trigger:
   branches:
     include:
-      - nightly-build
-      - refresh/4.*
-
-trigger:
-  branches:
-    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-  paths:
-    include:
-      - host/4/bullseye/amd64/base/*
-      - host/4/bullseye/amd64/powershell/powershell70/*
-      - host/4/bullseye/amd64/powershell/powershell72/*
-      - host/4/powershell-build.yml
+      - nightly-build
+      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -16,10 +16,15 @@ pr:
 trigger:
   branches:
     include:
+      - nightly-build
+      - refresh/4.*
+
+trigger:
+  branches:
+    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-      - refresh/4.*
   paths:
     include:
       - host/4/bullseye/amd64/base/*

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -1,5 +1,12 @@
 trigger: none
 # Publish pipelines are triggered via HTTP method in release pipeline. See v4 publish
+schedules:
+- cron: "0 3 * * *"
+  displayName: 3 AM Nightly Publish
+  branches:
+    include:
+    - nightly-build
+  always: true
 pool:
     vmImage: 'Ubuntu-latest'
 
@@ -10,6 +17,13 @@ steps:
     continueOnError: false
     env:
       pswd: $(dockerPassword)
+
+  - bash: |
+        echo "##vso[task.setvariable variable=PrivateVersion;]nightly-build"
+        echo "##vso[task.setvariable variable=TargetVersion;]4-nightly"
+      displayName: Set Nightly Build Variables
+      continueOnError: false
+      condition: eq(variables['Build.Reason'], 'Schedule')
 
   - bash: |
       set -e

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -15,20 +15,11 @@ pr:
 trigger:
   branches:
     include:
-      - nightly-build
-      - refresh/4.*
-
-trigger:
-  branches:
-    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-  paths:
-    include:
-      - host/4/bullseye/amd64/base/*
-      - host/4/bullseye/amd64/python/*
-      - host/4/python-build.yml
+      - nightly-build
+      - refresh/4.*
 
 variables:
   HOST_MAJOR_VERSION: 4

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -15,10 +15,15 @@ pr:
 trigger:
   branches:
     include:
+      - nightly-build
+      - refresh/4.*
+
+trigger:
+  branches:
+    include:
       - dev
       - refs/tags/4.*
       - release/4.x
-      - refresh/4.*
   paths:
     include:
       - host/4/bullseye/amd64/base/*


### PR DESCRIPTION
This PR should introduce a new nightly build pipeline that triggers a nightly release flow. The nightly build pipeline runs every night at midnight UTC and merges the newest bits on dev into a branch -> nightly-build then pushes that to remote. Nightly-build has been added as a trigger for all v4 build pipelines. So, the push to nightly-build should trigger builds of all images. Finally, the publish pipeline has been updated with a 3 AM cron job that should run after all builds have been finished. When the pipeline is triggered using the cron job, it targets the 'nightly-build' images and pushes them to publish on a 4-nightly tag schema

This PR also updates build pipelines in v4 with better re-fresh pipeline support.
### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
