### PR TITLE
Fixed indenting in publish.yml

### DIFF
--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -21,9 +21,9 @@ steps:
   - bash: |
         echo "##vso[task.setvariable variable=PrivateVersion;]nightly-build"
         echo "##vso[task.setvariable variable=TargetVersion;]4-nightly"
-      displayName: Set Nightly Build Variables
-      continueOnError: false
-      condition: eq(variables['Build.Reason'], 'Schedule')
+    displayName: Set Nightly Build Variables
+    continueOnError: false
+    condition: eq(variables['Build.Reason'], 'Schedule')
 
   - bash: |
       set -e


### PR DESCRIPTION
Indenting caused publish.yml to break in Azure DevOps.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
