### PR TITLE
Update Refresh Images Github Action

### DIFF
--- a/.github/workflows/re-fresh.yml
+++ b/.github/workflows/re-fresh.yml
@@ -23,6 +23,9 @@ jobs:
         git config --local user.name "Azure Functions"
         git fetch --all
         git checkout ${{ github.event.inputs.targetTag }}
+        date > refresh-time.txt
+        git add refresh-time.txt
+        git commit -m "Version Dependency Refresh"
         git checkout -b "refresh/${{ github.event.inputs.targetTag }}-refresh"
         cd host
         ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}

--- a/.github/workflows/re-fresh.yml
+++ b/.github/workflows/re-fresh.yml
@@ -25,7 +25,7 @@ jobs:
         git checkout ${{ github.event.inputs.targetTag }}
         date > refresh-time.txt
         git add refresh-time.txt
-        git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}""
+        git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}"
         git checkout -b "refresh/${{ github.event.inputs.targetTag }}-refresh"
         cd host
         ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}

--- a/.github/workflows/re-fresh.yml
+++ b/.github/workflows/re-fresh.yml
@@ -25,7 +25,7 @@ jobs:
         git checkout ${{ github.event.inputs.targetTag }}
         date > refresh-time.txt
         git add refresh-time.txt
-        git commit -m "Version Dependency Refresh"
+        git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}""
         git checkout -b "refresh/${{ github.event.inputs.targetTag }}-refresh"
         cd host
         ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}

--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -19,14 +19,8 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - release/3.x
       - refresh/3.*
-  paths:
-    include:
-      - host/3.0/buster/amd64/dotnet/*
-      - host/3.0/buster/arm32v7/dotnet/*
-      - host/3.0/bionic/arm32v7/dotnet/*
-      - host/3.0/dotnet-build.yml
+      - release/3.x
 
 variables:
 - name: image_list

--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -20,16 +20,8 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
+      - refresh/3.*      
       - release/3.x
-      - refresh/3.*
-  paths:
-    include:
-      - host/3.0/buster/amd64/base/*
-      - host/3.0/buster/amd64/java/java8/*
-      - host/3.0/buster/amd64/java/java8-zulu/*
-      - host/3.0/buster/amd64/java/java11/*
-      - host/3.0/buster/amd64/java/java11-zulu/*
-      - host/3.0/java-build.yml
 
 variables:
 - name: image_list

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -17,13 +17,8 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - release/3.x
       - refresh/3.*
-  paths:
-    include:
-      - host/3.0/buster/amd64/base/*
-      - host/3.0/buster/amd64/node/*
-      - host/3.0/node-build.yml
+      - release/3.x
 
 variables:
 - name: image_list

--- a/host/3.0/powershell-build.yml
+++ b/host/3.0/powershell-build.yml
@@ -19,14 +19,8 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - release/3.x
       - refresh/3.*
-  paths:
-    include:
-      - host/3.0/buster/amd64/base/*
-      - host/3.0/buster/amd64/powershell/powershell6/*
-      - host/3.0/buster/amd64/powershell/powershell7/*
-      - host/3.0/powershell-build.yml
+      - release/3.x
 
 variables:
 - name: image_list

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -17,13 +17,8 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - release/3.x
       - refresh/3.*
-  paths:
-    include:
-      - host/3.0/buster/amd64/base/*
-      - host/3.0/buster/amd64/python/*
-      - host/3.0/python-build.yml
+      - release/3.x
 
 variables:
   image_list: ''

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -17,9 +17,9 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
+      - refresh/4.*
       - release/4.x
       - nightly-build
-      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -21,9 +21,9 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
+      - refresh/4.*
       - release/4.x
       - nightly-build
-      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -17,9 +17,9 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
+      - refresh/4.*
       - release/4.x
       - nightly-build
-      - refresh/4.*
 
 steps:
   - bash: |

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -18,9 +18,9 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
+      - refresh/4.*
       - release/4.x
       - nightly-build
-      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -17,9 +17,9 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
+      - refresh/4.*
       - release/4.x
       - nightly-build
-      - refresh/4.*
 
 variables:
   HOST_MAJOR_VERSION: 4


### PR DESCRIPTION
The refresh pipelines are having a hard time automatically triggering builds for v3/v4 images. The wildcard that should be matching refresh branches is not successfully operating.  This seems to be a bug with Azure Devops. I was able to override the triggers from Azure Devops UI and match the refresh branch with wildcards as expected.

This PR moves the wildcard trigger to away from the bottom of the trigger list and partially simplifies v3 pipelines. I am not sure that this will resolve the wildcard matching bug, but it is a safe change and I will continue to improve these pipelines.