### PR TITLE
Update trigger for GH Action to use API request

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,10 +1,9 @@
-name: Re-Fresh Non-appservice Images
+name: Refresh Non-appservice Images
+
 on:
-  workflow_dispatch:
-    inputs:
-      targetTag:
-        description: 'Tag to re-fresh (e.g. 4.9.0)'
-        required: true
+  repository_dispatch:
+    types: [refresh]
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,13 +21,13 @@ jobs:
         git config --local user.email "azfuncgh@github.com"
         git config --local user.name "Azure Functions"
         git fetch --all
-        git checkout ${{ github.event.inputs.targetTag }}
+        git checkout ${{ github.event.client_payload.targetTag }}
         date > refresh-time.txt
         git add refresh-time.txt
-        git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}"
-        git checkout -b "refresh/${{ github.event.inputs.targetTag }}-refresh"
+        git commit -m "Refresh Images for ${{ github.event.client_payload.targetTag }}"
+        git checkout -b "refresh/${{ github.event.client_payload.targetTag }}-refresh"
         cd host
-        ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}
-        git push origin "refresh/${{ github.event.inputs.targetTag }}-refresh" --force
+        ./verify-republish-pipeline.sh ${{ github.event.client_payload.targetTag }}
+        git push origin "refresh/${{ github.event.client_payload.targetTag }}-refresh" --force
       env:
         GITHUB_TOKEN: ${{ secrets.PIPELINE_ADMIN }} 


### PR DESCRIPTION
Update the trigger for the refresh github action to use repository_dispatch instead of workflow_dispatch. This will allow us to automatically trigger the refresh action to simplify the refresh release process. 

API requests will target the /refresh workflow endpoint with targetTag as a request_payload.  Otherwise the action will operate the same way