### PR TITLE
Move refresh actions to static major version branches

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,9 +1,9 @@
-name: Re-Fresh Non-appservice Images
+name: Refresh Non-appservice Images
 on:
   workflow_dispatch:
     inputs:
       targetTag:
-        description: 'Tag to re-fresh (e.g. 4.9.0)'
+        description: 'Tag to refresh (e.g. 4.9.0)'
         required: true
 jobs:
   release:
@@ -26,9 +26,11 @@ jobs:
         date > refresh-time.txt
         git add refresh-time.txt
         git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}"
-        git checkout -b "refresh/${{ github.event.inputs.targetTag }}-refresh"
+        fullversion=${{ github.event.inputs.targetTag }}
+        majorversion=${fullversion:0:1}
+        git checkout -b "refresh/${majorversion}-refresh"
         cd host
         ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}
-        git push origin "refresh/${{ github.event.inputs.targetTag }}-refresh" --force
+        git push origin "refresh/${majorversion}-refresh" --force
       env:
         GITHUB_TOKEN: ${{ secrets.PIPELINE_ADMIN }} 

--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - "refresh/3.*"
+      - refresh/3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3.*
+      - "refresh/3.*"
       - release/3.x
 
 variables:

--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -20,7 +20,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - "refresh/3.*"      
+      - refresh/3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -20,7 +20,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3.*      
+      - "refresh/3.*"      
       - release/3.x
 
 variables:

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3.*
+      - "refresh/3.*"
       - release/3.x
 
 variables:

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - "refresh/3.*"
+      - refresh/3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/powershell-build.yml
+++ b/host/3.0/powershell-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - "refresh/3.*"
+      - refresh/3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/powershell-build.yml
+++ b/host/3.0/powershell-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3.*
+      - "refresh/3.*"
       - release/3.x
 
 variables:

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3.*
+      - "refresh/3.*"
       - release/3.x
 
 variables:

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - "refresh/3.*"
+      - refresh/3-refresh
       - release/3.x
 
 variables:

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4.*
+      - "refresh/4.*"
       - release/4.x
       - nightly-build
 

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - "refresh/4.*"
+      - refresh/4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -21,7 +21,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4.*
+      - "refresh/4.*"
       - release/4.x
       - nightly-build
 

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -21,7 +21,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - "refresh/4.*"
+      - refresh/4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4.*
+      - "refresh/4.*"
       - release/4.x
       - nightly-build
 

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - "refresh/4.*"
+      - refresh/4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -18,7 +18,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - "refresh/4.*"
+      - refresh/4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -18,7 +18,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4.*
+      - "refresh/4.*"
       - release/4.x
       - nightly-build
 

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4.*
+      - "refresh/4.*"
       - release/4.x
       - nightly-build
 

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - "refresh/4.*"
+      - refresh/4-refresh
       - release/4.x
       - nightly-build
 


### PR DESCRIPTION
This PR moves refresh pipeline related information to static git branches similar to the nightly-build.  When the action is triggered, we will force push a given tag to the "refresh/{MajorVersion}-refresh" branch.  This should allow us to automatically trigger image builds.  With that we can centralize the entire refresh image process to the release pipelines, this will simplify the process and allow any team member to perform it. 

Ex. Refresh Pipelines : https://azure-functions.visualstudio.com/azure-functions-docker/_releaseProgress?_a=release-pipeline-progress&releaseId=192
