### PR TITLE
Remove refresh prefix from refresh pipelines 

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -28,9 +28,9 @@ jobs:
         git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}"
         fullversion=${{ github.event.inputs.targetTag }}
         majorversion=${fullversion:0:1}
-        git checkout -b "refresh/${majorversion}-refresh"
+        git checkout -b "${majorversion}-refresh"
         cd host
         ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}
-        git push origin "refresh/${majorversion}-refresh" --force
+        git push origin "${majorversion}-refresh" --force
       env:
         GITHUB_TOKEN: ${{ secrets.PIPELINE_ADMIN }} 

--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3-refresh
+      - 3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -20,7 +20,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3-refresh
+      - 3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3-refresh
+      - 3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/powershell-build.yml
+++ b/host/3.0/powershell-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3-refresh
+      - 3-refresh
       - release/3.x
 
 variables:

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - refresh/3-refresh
+      - 3-refresh
       - release/3.x
 
 variables:

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4-refresh
+      - 4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -21,7 +21,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4-refresh
+      - 4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4-refresh
+      - 4-refresh
       - release/4.x
       - nightly-build
 

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -18,9 +18,9 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4-refresh
       - release/4.x
       - nightly-build
+      - 4-refresh
 
 variables:
 - name: image_list

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - refresh/4-refresh
+      - 4-refresh
       - release/4.x
       - nightly-build
 


### PR DESCRIPTION
CI pipelines are still having trouble picking up the statically named refresh branch.  This attempt will remove the prefix refresh to see if we can resolve that. It is still unknown why the CI is not picking up the refresh branches as expected. 


