### PR TITLE
Final update to refresh pipelines :)

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,10 +1,9 @@
 name: Refresh Non-appservice Images
+
 on:
-  workflow_dispatch:
-    inputs:
-      targetTag:
-        description: 'Tag to refresh (e.g. 4.9.0)'
-        required: true
+  repository_dispatch:
+    types: [refresh]
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -22,15 +21,13 @@ jobs:
         git config --local user.email "azfuncgh@github.com"
         git config --local user.name "Azure Functions"
         git fetch --all
-        git checkout ${{ github.event.inputs.targetTag }}
+        git checkout ${{ github.event.client_payload.targetTag }}
         date > refresh-time.txt
         git add refresh-time.txt
-        git commit -m "Refresh Images for ${{ github.event.inputs.targetTag }}"
-        fullversion=${{ github.event.inputs.targetTag }}
-        majorversion=${fullversion:0:1}
-        git checkout -b "${majorversion}-refresh"
+        git commit -m "Refresh Images for ${{ github.event.client_payload.targetTag }}"
+        git checkout -b "refresh/${{ github.event.client_payload.targetTag }}-refresh"
         cd host
-        ./verify-republish-pipeline.sh ${{ github.event.inputs.targetTag }}
-        git push origin "${majorversion}-refresh" --force
+        ./verify-republish-pipeline.sh ${{ github.event.client_payload.targetTag }}
+        git push origin "refresh/${{ github.event.client_payload.targetTag }}-refresh" --force
       env:
         GITHUB_TOKEN: ${{ secrets.PIPELINE_ADMIN }} 

--- a/host/3.0/dotnet-build.yml
+++ b/host/3.0/dotnet-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - 3-refresh
+      - refresh/3.*
       - release/3.x
 
 variables:

--- a/host/3.0/java-build.yml
+++ b/host/3.0/java-build.yml
@@ -20,7 +20,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - 3-refresh
+      - refresh/3.*
       - release/3.x
 
 variables:

--- a/host/3.0/node-build.yml
+++ b/host/3.0/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - 3-refresh
+      - refresh/3.*
       - release/3.x
 
 variables:

--- a/host/3.0/powershell-build.yml
+++ b/host/3.0/powershell-build.yml
@@ -19,7 +19,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - 3-refresh
+      - refresh/3.*
       - release/3.x
 
 variables:

--- a/host/3.0/python-build.yml
+++ b/host/3.0/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/3.*.*
-      - 3-refresh
+      - refresh/3.*
       - release/3.x
 
 variables:

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - 4-refresh
+      - refresh/4.*
       - release/4.x
       - nightly-build
 

--- a/host/4/java-build.yml
+++ b/host/4/java-build.yml
@@ -21,7 +21,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - 4-refresh
+      - refresh/4.*
       - release/4.x
       - nightly-build
 

--- a/host/4/node-build.yml
+++ b/host/4/node-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - 4-refresh
+      - refresh/4.*
       - release/4.x
       - nightly-build
 

--- a/host/4/powershell-build.yml
+++ b/host/4/powershell-build.yml
@@ -20,7 +20,7 @@ trigger:
       - refs/tags/4.*
       - release/4.x
       - nightly-build
-      - 4-refresh
+      - refresh/4.*
 
 variables:
 - name: image_list

--- a/host/4/python-build.yml
+++ b/host/4/python-build.yml
@@ -17,7 +17,7 @@ trigger:
     include:
       - dev
       - refs/tags/4.*
-      - 4-refresh
+      - refresh/4.*
       - release/4.x
       - nightly-build
 


### PR DESCRIPTION
With Tony's help I was able to determine why refresh pipelines were not working in the past. Turns out that yml pipelines with branch triggers implicitly use the branch's yml definition.  Which means that when trying to refresh version 4.14.0.3 for example, the yml definition of the build branch was old.  That was the cause of not picking up refreshed branches. 

This final update to the refresh pipelines themselves removes all changes made in the last few weeks and reverts back to the original design. Which will work.  Until a future release such as 4.16.0 though, the refresh branch will need to be manually updated or the builds will need to be manually triggered. After which point we can rely on this CI to succeed. 