### PR TITLE
Removing Powershell 7 from v4 Publish

### DIFF
--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -145,6 +145,16 @@ steps:
     displayName: tag and push node images
     continueOnError: false
 
+
+  - bash: |
+      set -e
+      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice
+      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-stage$(StageNumber)
+      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-stage$(StageNumber)
+      docker system prune -a -f
+    displayName: tag and push powershell images
+    continueOnError: false
+
   - bash: |
       set -e
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice

--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -147,23 +147,6 @@ steps:
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice
-
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-stage$(StageNumber)
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-stage$(StageNumber)
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-stage$(StageNumber)
-
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-stage$(StageNumber)
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-stage$(StageNumber)
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-stage$(StageNumber)
-
-      docker system prune -a -f
-    displayName: tag and push powershell images
-    continueOnError: false
-
-  - bash: |
-      set -e
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.7-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.8-appservice
       docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.9-appservice


### PR DESCRIPTION
Removing Powershell 7 images from v4 publish as per https://github.com/Azure/azure-functions-docker/pull/835.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
