### PR TITLE
Remove Powershell 7 images from refresh pipeline to reflect publish.yml

### DIFF
--- a/host/4/republish-nonappservice.yml
+++ b/host/4/republish-nonappservice.yml
@@ -208,27 +208,6 @@ steps:
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7
-      docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-slim
-
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7 $TARGET_REGISTRY/powershell:$(TargetVersion)
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-slim $TARGET_REGISTRY/powershell:$(TargetVersion)-slim
-
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7 $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7
-      docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-slim $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-slim
-
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-slim
-
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7
-      docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-slim
-
-      docker system prune -a -f
-    displayName: tag and push powershell 7 images
-    continueOnError: false
-
-  - bash: |
-      set -e
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2
       docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-slim
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

The refresh pipeline is currently failing for 4.16.4 because these images are being published by the refresh pipeline, but they were removed from publish.yml: `/powershell:$(TargetVersion) /powershell:$(TargetVersion)-powershell7 /powershell:$(TargetVersion)-powershell7-slim /powershell:$(TargetVersion)-slim`

https://github.com/Azure/azure-functions-docker/actions/runs/4442003357/jobs/7797764336#step:3:42

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
