### PR TITLE
Remove powershell 7 images from sovereign pipeline

### DIFF
--- a/host/4/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/4/publish-appservice-stage-sovereign-clouds.yml
@@ -156,17 +156,9 @@ steps:
 
       - bash: |
           set -e
-          docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice
           docker pull $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice
-          
-          docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
-          docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-$(CloudName)-stage${{stage}}
           docker tag $SOURCE_REGISTRY/powershell:$(PrivateVersion)-powershell7.2-appservice $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-$(CloudName)-stage${{stage}}
-          
-          docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-appservice-$(CloudName)-stage${{stage}}
-          docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7-appservice-$(CloudName)-stage${{stage}}
           docker push $TARGET_REGISTRY/powershell:$(TargetVersion)-powershell7.2-appservice-$(CloudName)-stage${{stage}}
-          
           docker system prune -a -f
         displayName: tag and push powershell images for stage ${{stage}}
         continueOnError: false


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

GitHub Action for creating new PR based on host version update is failing because the sovereign pipeline is publishing PowerShell 7 images: https://github.com/Azure/azure-functions-docker/actions/runs/4470807693/jobs/7854860496#step:3:13

This PR removes PowerShell 7 images to keep all three pipelines in sync with each other (public, republish, and sovereign pipelines). 

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
