### PR TITLE
Update Refresh Action Unit Test and get pipelines to parity

### DIFF
--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -40,16 +40,20 @@ steps:
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/dotnet:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/base:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/base:$(TargetVersion)-slim
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/base:$(TargetVersion)-appservice
 
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-appservice
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
       docker push $TARGET_REGISTRY/base:$(TargetVersion)
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-slim
+      docker push $TARGET_REGISTRY/base:$(TargetVersion)-appservice
 
       docker system prune -a -f
     displayName: tag and push dotnet images
@@ -114,9 +118,15 @@ steps:
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java17-build
       docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java17-appservice
 
+      docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java8.1-appservice
+      docker pull $SOURCE_REGISTRY/java:$(PrivateVersion)-java11.1-appservice
+
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8 $TARGET_REGISTRY/java:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim $TARGET_REGISTRY/java:$(TargetVersion)-slim
-      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:$(TargetVersion)-appservice
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:$(TargetVersion)-
+      
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8.1-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java8.1-appservice
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11.1-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java11.1-appservice
 
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8 $TARGET_REGISTRY/java:$(TargetVersion)-java8
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim $TARGET_REGISTRY/java:$(TargetVersion)-java8-slim
@@ -137,6 +147,9 @@ steps:
       docker push $TARGET_REGISTRY/java:$(TargetVersion)
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-appservice
+
+      docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8.1-appservice
+      docker push $TARGET_REGISTRY/java:$(TargetVersion)-java11.1-appservice
 
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8
       docker push $TARGET_REGISTRY/java:$(TargetVersion)-java8-slim
@@ -290,6 +303,7 @@ steps:
       docker push $TARGET_REGISTRY/python:$(TargetVersion)
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-buildenv
+      docker push $TARGET_REGISTRY/python:$(TargetVersion)-appservice
 
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7
       docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.7-slim

--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -123,7 +123,7 @@ steps:
 
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8 $TARGET_REGISTRY/java:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-slim $TARGET_REGISTRY/java:$(TargetVersion)-slim
-      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:$(TargetVersion)-
+      docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8-appservice $TARGET_REGISTRY/java:$(TargetVersion)-appservice
       
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java8.1-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java8.1-appservice
       docker tag $SOURCE_REGISTRY/java:$(PrivateVersion)-java11.1-appservice $TARGET_REGISTRY/java:$(TargetVersion)-java11.1-appservice

--- a/host/verify-republish-pipeline.sh
+++ b/host/verify-republish-pipeline.sh
@@ -27,7 +27,7 @@ else
    TARGET="./4"
 fi
 
-repub=($(((grep "docker push".* ${TARGET}/republish-nonappservice.yml) | awk -F 'TARGET_REGISTRY' '{print $2}') ))
+repub=($(((grep "docker push".* ${TARGET}/republish.yml) | awk -F 'TARGET_REGISTRY' '{print $2}') ))
 
 pub=($(((((grep "docker push".*  ${TARGET}/publish.yml)| grep -v appservice)| grep -v nanoserver) | awk -F 'TARGET_REGISTRY' '{print $2}') ))
 

--- a/host/verify-republish-pipeline.sh
+++ b/host/verify-republish-pipeline.sh
@@ -29,7 +29,8 @@ fi
 
 repub=($(((grep "docker push".* ${TARGET}/republish.yml) | awk -F 'TARGET_REGISTRY' '{print $2}') ))
 
-pub=($(((((grep "docker push".*  ${TARGET}/publish.yml)| grep -v appservice)| grep -v nanoserver) | awk -F 'TARGET_REGISTRY' '{print $2}') ))
+
+pub=($(((((grep "docker push".*  ${TARGET}/publish.yml)| grep -v quickstart)| grep -v nanoserver) | awk -F 'TARGET_REGISTRY' '{print $2}') ))
 
 difference=($(comm -3 <(printf '%s\n' "${repub[@]}"|sort -u) <(printf '%s\n' "${pub[@]}"|sort -u)))
 
@@ -38,12 +39,12 @@ if [ -z "$difference" ]; then
   exit 0
 fi
 
-echo ${#difference[@]}
+echo ${difference[@]} | tr -d '\r'
 if [ ${#difference[@]} == 1 ] && [[ $difference == *"nanoserver"* ]]; then
    echo -e "Republish pipeline excludes nanoserver image. This is a known difference. Redeployment Safe. \n"
    exit 0
 else 
-   echo -e "Republish and Publish pipelines inconsistent. Other than the /base image all pipelines should publish the same non-appservice images. The following differences exist for non-appservice images between the pipelines: "
+   echo -e "Republish and Publish pipelines inconsistent. Other than the /base image all pipelines should publish the same non-appservice images. The following differences exist for appservice images between the pipelines: "
    echo -e ${difference[@]}
    exit 1
 fi

--- a/host/verify-republish-pipeline.sh
+++ b/host/verify-republish-pipeline.sh
@@ -44,7 +44,7 @@ if [ ${#difference[@]} == 1 ] && [[ $difference == *"nanoserver"* ]]; then
    echo -e "Republish pipeline excludes nanoserver image. This is a known difference. Redeployment Safe. \n"
    exit 0
 else 
-   echo -e "Republish and Publish pipelines inconsistent. Other than the /base image all pipelines should publish the same non-appservice images. The following differences exist for appservice images between the pipelines: "
+   echo -e "Republish and Publish pipelines inconsistent. Other than the /base image all pipelines should publish the same non-quickstart images. The following differences exist for images between the pipelines: "
    echo -e ${difference[@]}
    exit 1
 fi


### PR DESCRIPTION
When I tried to push a refresh, this Unit Test failed and notified us that there were disparities in our pipelines that could have caused some images to get left behind.  The unit test currently ignores -quickstart images but, this PR will bring all other images release to parity between staged and non-staged pipelines. 