### PR TITLE
Specify which PS worker to copy in PS images

### DIFF
--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-composite.template
@@ -20,7 +20,8 @@ RUN apt-get update && \
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
-COPY --from=runtime-image ["/workers/powershell", "/azure-functions-host/workers/powershell"]
+COPY --from=runtime-image ["/workers/powershell/worker.config.json", "/azure-functions-host/workers/powershell/worker.config.json"]
+COPY --from=runtime-image ["/workers/powershell/7", "/azure-functions-host/workers/powershell/7"]
 
 EXPOSE 2222 80
 

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70-slim.Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update && \
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
-COPY --from=runtime-image ["/workers/powershell", "/azure-functions-host/workers/powershell"]
+COPY --from=runtime-image ["/workers/powershell/worker.config.json", "/azure-functions-host/workers/powershell/worker.config.json"]
+COPY --from=runtime-image ["/workers/powershell/7", "/azure-functions-host/workers/powershell/7"]
 
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell70/powershell70.Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get update && \
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
-COPY --from=runtime-image ["/workers/powershell", "/azure-functions-host/workers/powershell"]
+COPY --from=runtime-image ["/workers/powershell/worker.config.json", "/azure-functions-host/workers/powershell/worker.config.json"]
+COPY --from=runtime-image ["/workers/powershell/7", "/azure-functions-host/workers/powershell/7"]
 
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-composite.template
@@ -17,7 +17,8 @@ RUN apt-get update && \
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
-COPY --from=runtime-image ["/workers/powershell", "/azure-functions-host/workers/powershell"]
+COPY --from=runtime-image ["/workers/powershell/worker.config.json", "/azure-functions-host/workers/powershell/worker.config.json"]
+COPY --from=runtime-image ["/workers/powershell/7.2", "/azure-functions-host/workers/powershell/7.2"]
 
 EXPOSE 2222 80
 

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72-slim.Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && \
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
-COPY --from=runtime-image ["/workers/powershell", "/azure-functions-host/workers/powershell"]
+COPY --from=runtime-image ["/workers/powershell/worker.config.json", "/azure-functions-host/workers/powershell/worker.config.json"]
+COPY --from=runtime-image ["/workers/powershell/7.2", "/azure-functions-host/workers/powershell/7.2"]
 
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
+++ b/host/4/bullseye/amd64/powershell/powershell72/powershell72.Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && \
 # copy bundles, host runtime and powershell worker from the build image
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image ["/FuncExtensionBundles", "/FuncExtensionBundles"]
-COPY --from=runtime-image ["/workers/powershell", "/azure-functions-host/workers/powershell"]
+COPY --from=runtime-image ["/workers/powershell/worker.config.json", "/azure-functions-host/workers/powershell/worker.config.json"]
+COPY --from=runtime-image ["/workers/powershell/7.2", "/azure-functions-host/workers/powershell/7.2"]
 
 CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]


### PR DESCRIPTION
Currently Powershell images contain all powershell workers. Each image contains workers for 7, 7.2 and 7.4.  This is suboptimal because the workers are taking up unused space on the images.  7.2 and 7.4 workers are 80mb and 7 is 110Mb.  This is about 10% of total image size.  This PR optimizes those images by removing excess workers. 

