### PR TITLE
Retrieving jessie security updates from archives

### DIFF
--- a/host/3.0/buster/amd64/python/python36/python36-buildenv.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-buildenv.Dockerfile
@@ -194,7 +194,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python36/python36-composite.template
+++ b/host/3.0/buster/amd64/python/python36/python36-composite.template
@@ -196,7 +196,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -239,7 +239,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -239,7 +239,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    # echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    # echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python37/python37-buildenv.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-buildenv.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python37/python37-composite.template
+++ b/host/3.0/buster/amd64/python/python37/python37-composite.template
@@ -21,7 +21,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python38/python38-buildenv.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-buildenv.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python38/python38-composite.template
+++ b/host/3.0/buster/amd64/python/python38/python38-composite.template
@@ -21,7 +21,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python39/python39-buildenv.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-buildenv.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python39/python39-composite.template
+++ b/host/3.0/buster/amd64/python/python39/python39-composite.template
@@ -21,7 +21,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \

--- a/host/3.0/buster/amd64/python/python39/python39.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39.Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
-    echo 'deb http://security.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
+    echo 'deb http://archive.debian.org/debian-security jessie/updates main' >> /etc/apt/sources.list && \
     # install necessary locales for MS SQL
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
Our v3 build started failing with the error 
E: The repository 'http://security.debian.org/debian-security jessie/updates Release' does not have a Release file. 

From the error it seems like jessie/updates have been removed from security.debian.org. Fix is to pull the jessie updates from the debian archive link. archieve.debian.org. 

<!-- If you are doing releasing a new host version, please add the release page links of the version -->
Releasing new Host versions.
[V3 Release](PASTE_V3_LINK_HERE)
[V2 Release](PASTE_V2_LINK_HERE)

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
