### PR TITLE
Revert Host Version v3 to 3.19.0 for v3 Host Versions

### DIFF
--- a/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/bionic/arm32v7/dotnet/dotnet.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/base/host.Dockerfile
+++ b/host/3.0/buster/amd64/base/host.Dockerfile
@@ -16,6 +16,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/base/host.Dockerfile
+++ b/host/3.0/buster/amd64/base/host.Dockerfile
@@ -32,7 +32,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
     find /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/bin/runtimes/ -mindepth 1 -type d -not -name "linux-x64" -prune -exec rm -rf {} + && \
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet-slim.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/3.0/buster/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -18,6 +18,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11-slim.Dockerfile
@@ -32,7 +32,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -18,6 +18,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/java/java11/java11.Dockerfile
+++ b/host/3.0/buster/amd64/java/java11/java11.Dockerfile
@@ -32,7 +32,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -33,7 +33,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8-slim.Dockerfile
@@ -19,6 +19,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -33,7 +33,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/java/java8/java8.Dockerfile
+++ b/host/3.0/buster/amd64/java/java8/java8.Dockerfile
@@ -19,6 +19,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10-slim.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/node/node10/node10.Dockerfile
+++ b/host/3.0/buster/amd64/node/node10/node10.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12-slim.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/node/node12/node12.Dockerfile
+++ b/host/3.0/buster/amd64/node/node12/node12.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14-slim.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/node/node14/node14.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/node/node14/node14.Dockerfile
+++ b/host/3.0/buster/amd64/node/node14/node14.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     rm -rf /root/.local /root/.nuget /src && \
     find /workers/node/dist/src/grpc/src/node/extension_binary/ -mindepth 1 -type d ! -regex ".*linux-x64.*" -prune -exec rm -rf '{}' \;
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36-slim.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python36/python36.Dockerfile
+++ b/host/3.0/buster/amd64/python/python36/python36.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37-slim.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python37/python37.Dockerfile
+++ b/host/3.0/buster/amd64/python/python37/python37.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38-slim.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python38/python38.Dockerfile
+++ b/host/3.0/buster/amd64/python/python38/python38.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39-slim.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/amd64/python/python39/python39.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39.Dockerfile
@@ -27,7 +27,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/amd64/python/python39/python39.Dockerfile
+++ b/host/3.0/buster/amd64/python/python39/python39.Dockerfile
@@ -13,6 +13,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \

--- a/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
@@ -28,7 +28,7 @@ RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 && \
-    EXTENSION_BUNDLE_VERSION_V3=3.20.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.19.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
+++ b/host/3.0/buster/arm32v7/dotnet/dotnet.Dockerfile
@@ -14,6 +14,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
+## Do not upgrade Extension Bundles for v3 images.  They are manually capped in the Host.   Link : https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b
 RUN EXTENSION_BUNDLE_VERSION=1.8.1 && \
     EXTENSION_BUNDLE_FILENAME=Microsoft.Azure.Functions.ExtensionBundle.1.8.1_linux-x64.zip && \
     apt-get update && \


### PR DESCRIPTION
Internal discussion has found that Host Major version 3 should not have been updated from v3.19.0.  This PR reverts the definitions back to 3.19.0

https://github.com/Azure/azure-functions-host/commit/d251aef1d33a585294a849e6750c4a950d75fc1b