### PR TITLE
Adding dotnet:4-alpine image

### DIFF
--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -8,6 +8,9 @@ ENV PublishWithAspNetCoreTargetManifest=false
 RUN apk update && apk upgrade && \
     apk --no-cache add git gnupg wget unzip grpc grpc-plugins protobuf protobuf-dev protoc
 
+ENV GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
+ENV PROTOBUF_PROTOC=/usr/bin/protoc
+
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -1,0 +1,55 @@
+# Build the runtime from source
+ARG HOST_VERSION=4.25.2
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS runtime-image
+ARG HOST_VERSION
+
+ENV PublishWithAspNetCoreTargetManifest=false
+
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+    cd /src/azure-functions-host && \
+    HOST_COMMIT=$(git rev-list -1 HEAD) && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
+    rm -rf /root/.local /root/.nuget /src
+
+RUN apt-get update && \
+    apt-get install -y gnupg wget unzip && \
+    EXTENSION_BUNDLE_VERSION_V2=2.27.0 && \
+    EXTENSION_BUNDLE_FILENAME_V2=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V2}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/$EXTENSION_BUNDLE_FILENAME_V2 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
+    EXTENSION_BUNDLE_VERSION_V3=3.26.0 && \
+    EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V3 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
+    EXTENSION_BUNDLE_VERSION_V4=4.8.0 && \
+    EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V4}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4/$EXTENSION_BUNDLE_FILENAME_V4 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V4 &&\
+    find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine
+ARG HOST_VERSION
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=dotnet \
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
+
+# Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
+RUN apt-get update && \
+    apt-get install -y libc-dev
+
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+
+CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -6,7 +6,7 @@ ARG HOST_VERSION
 ENV PublishWithAspNetCoreTargetManifest=false
 
 RUN apk update && apk upgrade && \
-    apk --no-cache add git gnupg wget unzip
+    apk --no-cache add git gnupg wget unzip grpc grpc-plugins protobuf protobuf-dev protoc
 
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -5,8 +5,8 @@ ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
-RUN apt-get update && \
-    apt-get install -y gnupg wget unzip
+RUN apk update && apk upgrade && \
+    apk --no-cache add git gnupg wget unzip
 
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -15,7 +15,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-musl-x64 && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile
@@ -5,6 +5,9 @@ ARG HOST_VERSION
 
 ENV PublishWithAspNetCoreTargetManifest=false
 
+RUN apt-get update && \
+    apt-get install -y gnupg wget unzip
+
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
@@ -13,9 +16,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src
 
-RUN apt-get update && \
-    apt-get install -y gnupg wget unzip && \
-    EXTENSION_BUNDLE_VERSION_V2=2.27.0 && \
+RUN EXTENSION_BUNDLE_VERSION_V2=2.27.0 && \
     EXTENSION_BUNDLE_FILENAME_V2=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V2}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/$EXTENSION_BUNDLE_FILENAME_V2 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/sshd_config
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/sshd_config
@@ -1,0 +1,15 @@
+# This is ssh server systemwide configuration file.
+#
+# /etc/sshd_config
+
+Port 			SSH_PORT
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes

--- a/host/4/alpine/amd64/dotnet/dotnet-inproc/start.sh
+++ b/host/4/alpine/amd64/dotnet/dotnet-inproc/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+export DOTNET_USE_POLLING_FILE_WATCHER=true
+
+if [ -z $PORT ]; then
+  export ASPNETCORE_URLS=http://*:80
+else
+  export ASPNETCORE_URLS=http://*:$PORT
+fi
+
+if [ -z $SSH_PORT ]; then
+  export SSH_PORT=2222
+fi
+
+if [ "$APPSVC_REMOTE_DEBUGGING" == "TRUE" ]; then
+    export languageWorkers__node__arguments="--inspect=0.0.0.0:$APPSVC_TUNNEL_PORT"
+    export languageWorkers__python__arguments="-m ptvsd --host localhost --port $APPSVC_TUNNEL_PORT"
+fi
+
+sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
+
+service ssh start
+
+if [ -f /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost ]; then
+    /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost
+else
+    dotnet /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll
+fi

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -86,6 +86,19 @@ steps:
 
   - bash: |
       set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet:$(Build.SourceBranchName)
+      echo "##vso[task.setvariable variable=image_list;]$IMAGE_NAME"
+
+      docker build -t $IMAGE_NAME \
+                  -f host/4/alpine/amd64/dotnet/dotnet-inproc/dotnet.Dockerfile \
+                  host/4/alpine/amd64/dotnet/dotnet-inproc/
+      npm run test $IMAGE_NAME --prefix test/
+      docker push $IMAGE_NAME
+    displayName: dotnet-inproc-alpine
+    continueOnError: false
+
+  - bash: |
+      set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet-isolated:$(Build.SourceBranchName)-dotnet-isolated6.0
       IMAGE_ARRAY="$(image_list),$IMAGE_NAME"
       echo "##vso[task.setvariable variable=image_list;]$IMAGE_ARRAY"

--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -37,11 +37,13 @@ steps:
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-alpine
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/dotnet:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-alpine $TARGET_REGISTRY/dotnet:$(TargetVersion)-alpine
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/base:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/base:$(TargetVersion)-slim
@@ -51,6 +53,7 @@ steps:
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-appservice
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-alpine
       docker push $TARGET_REGISTRY/base:$(TargetVersion)
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-appservice


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

Adding alpine support for dotnet, motivated by the large number of image vulnerabilities [mostly reported for Debian](https://github.com/Azure/azure-functions-docker/issues?q=is%3Aissue+is%3Aopen+CVE).
This is a POC PR to hopefully get the ball rolling on this issue: https://github.com/Azure/azure-functions-docker/issues/901 with changes I based off https://github.com/Azure/azure-functions-docker/pull/924 

Note: I am using the contents of this new Dockerfile internally instead of `FROM mcr.microsoft.com/azure-functions/dotnet:4` in order to meet security requirements, at time of writing there are no vulnerabilities reported when scanning the resulting image.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
