### PR TITLE
Adding net8 dotnet isolated image tags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Linux amd64 Tags
 | `4-dotnet-isolated7.0-slim`               | Debian 11 |
 | `4-dotnet-isolated7.0-appservice`         | Debian 11 |
 | `4-dotnet-isolated7.0-appservice-quickstart` | Debian 11 |
+| `4-dotnet-isolated8.0`                    | Debian 12 |
+| `4-dotnet-isolated8.0-slim`               | Debian 12 |
+| `4-dotnet-isolated8.0-appservice`         | Debian 12 |
 
 #### Node
 


### PR DESCRIPTION
Adding net8 dotnet isolated image tags to README

Public preview announcement for Linux support is out.
https://azure.microsoft.com/en-us/updates/public-preview-azure-functions-net-8-support-in-linux-plans/
