### PR TITLE
.NET RC1 update - Updating net8 dotnet-isolated images to remove "preview" from tag name. 

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-composite.template
@@ -1,5 +1,5 @@
 # TO DO : Replace preview tags. https://github.com/Azure/azure-functions-docker/issues/927
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim-amd64
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 
 COPY sshd_config /etc/ssh/

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-composite.template
@@ -1,4 +1,3 @@
-# TO DO : Replace preview tags. https://github.com/Azure/azure-functions-docker/issues/927
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get install -y gnupg wget unzip
 
 # TO DO : Replace preview tags. https://github.com/Azure/azure-functions-docker/issues/927
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim-amd64
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
@@ -16,7 +16,6 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
 RUN apt-get update && \
     apt-get install -y gnupg wget unzip
 
-# TO DO : Replace preview tags. https://github.com/Azure/azure-functions-docker/issues/927
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get install -y gnupg wget unzip
 
 # TO DO : Replace preview tags. https://github.com/Azure/azure-functions-docker/issues/927
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-preview-bookworm-slim-amd64
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
@@ -16,7 +16,6 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
 RUN apt-get update && \
     apt-get install -y gnupg wget unzip
 
-# TO DO : Replace preview tags. https://github.com/Azure/azure-functions-docker/issues/927
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 


### PR DESCRIPTION
.NET8 RC1 was released earlier today.
Updating net8 dotnet-isolated images to remove "preview" from tag name. 

Picked the most appropriate tag from the list here: https://github.com/dotnet/dotnet-docker/blob/main/README.aspnet.md#net-8-preview-tags

The list had rc version specific tag  (Ex: rc.1) I avoided that because that will force us to update the image again when rc2 is published. for preview, they had a generic preview one (without preview version). Since it is RC version, I feel more comfortable using the more generic image tag (which will pull the GA version as well when it is released)
