### PR TITLE
Temporary release pipeline just for dotnet 8 images.

### DIFF
--- a/host/4/publish-appservice-stage-dotnet-8.yml
+++ b/host/4/publish-appservice-stage-dotnet-8.yml
@@ -1,0 +1,50 @@
+trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See [App Service] v4 stage release
+pool:
+    vmImage: 'Ubuntu-latest'
+
+steps:
+  - bash: |
+      set -e
+      echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+    displayName: login
+    continueOnError: false
+    env:
+      pswd: $(dockerPassword)
+
+  - bash: |
+      set -e
+      SOURCE_REGISTRY=azurefunctions.azurecr.io/azure-functions/4
+      TARGET_REGISTRY=azurefunctions.azurecr.io/public/azure-functions
+
+      if [ -z "$(TargetVersion)" ]; then
+        echo "ERROR: TargetVersion is required"
+        exit 1
+      fi
+
+      if [ -z "$(PrivateVersion)" ]; then
+        echo "ERROR: PrivateVersion is required"
+        exit 1
+      fi
+
+      if [ -z "$(StageNumber)" ]; then
+        echo "ERROR: StageNumber is required"
+        exit 1
+      fi
+
+      echo "##vso[task.setvariable variable=SOURCE_REGISTRY]$SOURCE_REGISTRY"
+      echo "##vso[task.setvariable variable=TARGET_REGISTRY]$TARGET_REGISTRY"
+    displayName: set env
+    continueOnError: false
+
+  - bash: |
+      set -e
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-appservice
+
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-appservice-stage$(StageNumber)
+
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-appservice-stage$(StageNumber)
+
+      docker system prune -a -f
+    displayName: tag and push dotnet-isolated8 images
+    continueOnError: false

--- a/host/4/publish-dotnet-8.yml
+++ b/host/4/publish-dotnet-8.yml
@@ -1,0 +1,66 @@
+trigger: none
+# Publish pipelines are triggered via HTTP method in release pipeline. See v4 publish
+schedules:
+- cron: "0 3 * * *"
+  displayName: 3 AM Nightly Publish
+  branches:
+    include:
+    - nightly-build
+  always: true
+pool:
+    vmImage: 'Ubuntu-latest'
+
+steps:
+  - bash: |
+      echo $pswd | docker login -u $(dockerUsername) --password-stdin azurefunctions.azurecr.io
+    displayName: login
+    continueOnError: false
+    env:
+      pswd: $(dockerPassword)
+
+  - bash: |
+        echo "##vso[task.setvariable variable=PrivateVersion;]nightly-build"
+        echo "##vso[task.setvariable variable=TargetVersion;]4-nightly"
+    displayName: Set Nightly Build Variables
+    continueOnError: false
+    condition: eq(variables['Build.Reason'], 'Schedule')
+
+  - bash: |
+      set -e
+      SOURCE_REGISTRY=azurefunctions.azurecr.io/azure-functions/4
+      TARGET_REGISTRY=azurefunctions.azurecr.io/public/azure-functions
+
+      if [ -z "$(TargetVersion)" ]; then
+        echo "ERROR: TargetVersion is required"
+        exit 1
+      fi
+
+      if [ -z "$(PrivateVersion)" ]; then
+        echo "ERROR: PrivateVersion is required"
+        exit 1
+      fi
+
+      echo "##vso[task.setvariable variable=SOURCE_REGISTRY]$SOURCE_REGISTRY"
+      echo "##vso[task.setvariable variable=TARGET_REGISTRY]$TARGET_REGISTRY"
+    displayName: set env
+    continueOnError: false
+
+  - bash: |
+      set -e
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-slim
+      docker pull $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-appservice
+
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0 $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-slim $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-slim
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-appservice
+      docker tag $SOURCE_REGISTRY/dotnet-isolated:$(PrivateVersion)-dotnet-isolated8.0-appservice $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-appservice-quickstart
+
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-slim
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-appservice
+      docker push $TARGET_REGISTRY/dotnet-isolated:$(TargetVersion)-dotnet-isolated8.0-appservice-quickstart
+
+      docker system prune -a -f
+    displayName: tag and push dotnet8-isolated images
+    continueOnError: false


### PR DESCRIPTION
Based on our discussion, creating release pipelines for dotnet 8 images.

In the future, I see two paths for this.

1. We have individual release pipelines for every image
2. We have a variable passed in to the single .yml to specify if we are only releasing a single version / worker's images

For now, this will unblock us.

Process would be:

1. Create hotfix image
2. Tag (with builds for all language workers)
3. Push images to container repository (using `publish-dotnet-8.yml`)
4. Push to each stage (using `publish-appservice-stage-dotnet-8.yml`)

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
