### PR TITLE
Provide Dotnet 6 Host Image with Bookworm OS. 

### DIFF
--- a/host/4/bookworm/dotnet/dotnet6.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet6.Dockerfile
@@ -1,0 +1,53 @@
+# Build the runtime from source
+ARG HOST_VERSION=4.26.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
+ARG HOST_VERSION
+
+ENV PublishWithAspNetCoreTargetManifest=false
+
+RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
+    git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
+    cd /src/azure-functions-host && \
+    HOST_COMMIT=$(git rev-list -1 HEAD) && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 && \
+    mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
+    rm -rf /root/.local /root/.nuget /src
+
+RUN apt-get update && \
+    apt-get install -y gnupg wget unzip && \
+    EXTENSION_BUNDLE_VERSION_V2=2.28.0 && \
+    EXTENSION_BUNDLE_FILENAME_V2=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V2}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/$EXTENSION_BUNDLE_FILENAME_V2 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
+    find /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/bin/runtimes/ -mindepth 1 -type d -not -name "linux-x64" -prune -exec rm -rf {} + && \
+    EXTENSION_BUNDLE_VERSION_V3=3.27.0 && \
+    EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V3 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V3 &&\
+    find /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/bin/runtimes/ -mindepth 1 -type d -not -name "linux-x64" -prune -exec rm -rf {} + && \
+    EXTENSION_BUNDLE_VERSION_V4=4.9.0 && \
+    EXTENSION_BUNDLE_FILENAME_V4=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V4}_linux-x64.zip && \
+    wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4/$EXTENSION_BUNDLE_FILENAME_V4 && \
+    mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4 && \
+    unzip /$EXTENSION_BUNDLE_FILENAME_V4 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V4 && \
+    rm -f /$EXTENSION_BUNDLE_FILENAME_V4 &&\
+    find /FuncExtensionBundles/ -type f -exec chmod 644 {} \;
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-bookworm-slim-amd64
+ARG HOST_VERSION
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=dotnet \
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    HOST_VERSION=${HOST_VERSION} \
+    ASPNETCORE_CONTENTROOT=/azure-functions-host
+
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
+
+CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]

--- a/host/4/bookworm/dotnet/dotnet6.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.26.0
+ARG HOST_VERSION=4.27.2
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -222,10 +222,13 @@ steps:
                   host/4/bullseye/amd64/out/dotnet/
       npm run test $IMAGE_NAME --prefix  test/
       docker push $IMAGE_NAME
+
+      docker system df -v
     displayName: dotnet-isolated-appservice (.NET 8 Preview)
     continueOnError: false
 
   - bash: |
+      docker system df -v
       set -e
       IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet:$(Build.SourceBranchName)-dotnet6-bookworm
       IMAGE_ARRAY="$(image_list),$IMAGE_NAME"

--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -10,6 +10,7 @@ pr:
     include:
       - host/4/bullseye/amd64/base/*
       - host/4/bullseye/amd64/dotnet/*
+      - host/4/bookworm/dotnet/*
       - host/4/mariner/dotnet/*
       - host/4/dotnet-build.yml
 
@@ -223,6 +224,21 @@ steps:
       docker push $IMAGE_NAME
     displayName: dotnet-isolated-appservice (.NET 8 Preview)
     continueOnError: false
+
+  - bash: |
+      set -e
+      IMAGE_NAME=azurefunctions.azurecr.io/azure-functions/4/dotnet:$(Build.SourceBranchName)-dotnet6-bookworm
+      IMAGE_ARRAY="$(image_list),$IMAGE_NAME"
+      echo "##vso[task.setvariable variable=image_list;]$IMAGE_ARRAY"
+
+      docker build -t $IMAGE_NAME \
+                  -f host/4/bookworm/dotnet/dotnet6.Dockerfile \
+                  host/4/bookworm/dotnet
+      npm run test $IMAGE_NAME --prefix  test/
+      docker push $IMAGE_NAME
+    displayName: dotnet6-bookworm
+    continueOnError: false
+
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Manifest Generator'

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -50,12 +50,14 @@ steps:
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet6-bookworm
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/dotnet:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice-quickstart
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet6-bookworm $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-bookworm
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/base:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/base:$(TargetVersion)-slim
@@ -69,6 +71,7 @@ steps:
       docker push $TARGET_REGISTRY/base:$(TargetVersion)
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-appservice
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-bookworm
 
       docker system prune -a -f
     displayName: tag and push dotnet images

--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -37,11 +37,13 @@ steps:
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet6-bookworm
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/dotnet:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/dotnet:$(TargetVersion)-slim
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-appservice
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-appservice
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet6-bookworm $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-bookworm
 
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion) $TARGET_REGISTRY/base:$(TargetVersion)
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-slim $TARGET_REGISTRY/base:$(TargetVersion)-slim
@@ -54,6 +56,7 @@ steps:
       docker push $TARGET_REGISTRY/base:$(TargetVersion)
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-slim
       docker push $TARGET_REGISTRY/base:$(TargetVersion)-appservice
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet6-bookworm
 
       docker system prune -a -f
     displayName: tag and push dotnet images


### PR DESCRIPTION
Azure Functions needs a bookworm based Dotnet Image for downstream applications. This image is not syndicated to sov and will not be released to staged image locations. 