### PR TITLE
Add text file to force uncached Azure Devops build for release 4.27.5.2

### DIFF
--- a/host/4/force-new-build.txt
+++ b/host/4/force-new-build.txt
@@ -1,0 +1,1 @@
+Dotnet8 GA release Build Trigger file - This file prevents the re-use of a previous build in the creation of the Linux docker files. 


### PR DESCRIPTION
This PR adds only a text file to the repo to prevent Azure Devops from accidentally caching the build from the 4.27.5 bits which are the same