### PR TITLE
Update Functions Mariner image to be current with 4.27.7

### DIFF
--- a/host/4/mariner/dotnet/dotnet-isolated/dotnet7-isolated.Dockerfile
+++ b/host/4/mariner/dotnet/dotnet-isolated/dotnet7-isolated.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.26.0
+ARG HOST_VERSION=4.27.7
 FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS runtime-image
 ARG HOST_VERSION
 


### PR DESCRIPTION
Mariner image fell behind of other images in some of the recent deployment work.  This should get the image back into sync with the rest of our images. Which allows it to update automatically through find and replace. 

