### PR TITLE
Create Host Version and Extension Bundles Validation Script

### DIFF
--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -26,6 +26,7 @@ jobs:
         ./verify-pipelines.sh ${{ github.event.inputs.majorVersion }}
         ./update-version.sh ${{ github.event.inputs.majorVersion }} ${{ github.event.inputs.targetVersion }}
         ./validate-hostversion.sh ${{ github.event.inputs.majorVersion }}
+        ./validate-extbundle.sh ${{ github.event.inputs.majorVersion }}
         git add .
         git commit -m "Update Version ${{ github.event.inputs.targetVersion }}"
     - name: Create PullRequest

--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -25,6 +25,7 @@ jobs:
         cd host
         ./verify-pipelines.sh ${{ github.event.inputs.majorVersion }}
         ./update-version.sh ${{ github.event.inputs.majorVersion }} ${{ github.event.inputs.targetVersion }}
+        ./validate-hostversion.sh ${{ github.event.inputs.majorVersion }}
         git add .
         git commit -m "Update Version ${{ github.event.inputs.targetVersion }}"
     - name: Create PullRequest

--- a/.github/workflows/autopr.yaml
+++ b/.github/workflows/autopr.yaml
@@ -19,6 +19,8 @@ jobs:
       with:
         ref: dev
     - id: createBranch
+    # Validate-hostVersion and validate-extbundle are custom scripts to ensure all images share the same version
+    # They can be safely removed if blocking a hotfix release.  Ex. Only Python Images need to be updated. 
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"

--- a/host/4/bookworm/dotnet/dotnet6.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet6.Dockerfile
@@ -15,14 +15,14 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
 
 RUN apt-get update && \
     apt-get install -y gnupg wget unzip && \
-    EXTENSION_BUNDLE_VERSION_V2=2.28.0 && \
+    EXTENSION_BUNDLE_VERSION_V2=2.30.0 && \
     EXTENSION_BUNDLE_FILENAME_V2=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V2}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/$EXTENSION_BUNDLE_FILENAME_V2 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     unzip /$EXTENSION_BUNDLE_FILENAME_V2 -d /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2 && \
     rm -f /$EXTENSION_BUNDLE_FILENAME_V2 &&\
     find /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V2/bin/runtimes/ -mindepth 1 -type d -not -name "linux-x64" -prune -exec rm -rf {} + && \
-    EXTENSION_BUNDLE_VERSION_V3=3.27.0 && \
+    EXTENSION_BUNDLE_VERSION_V3=3.29.0 && \
     EXTENSION_BUNDLE_FILENAME_V3=Microsoft.Azure.Functions.ExtensionBundle.${EXTENSION_BUNDLE_VERSION_V3}_linux-x64.zip && \
     wget https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3/$EXTENSION_BUNDLE_FILENAME_V3 && \
     mkdir -p /FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/$EXTENSION_BUNDLE_VERSION_V3 && \

--- a/host/validate-extbundle.sh
+++ b/host/validate-extbundle.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+if [ "$1" == "3" ]; then
+   echo -e "MajorVersion 3 detected. Verifying Extension Bundles in host/3.0/"
+   TARGET="./3.0"
+else 
+   echo -e "MajorVersion 4 detected. Verifying Extension Bundles in host/4/"
+   TARGET="./4"
+fi
+
+check_extension_bundle() {
+  # Assume the docker files are in the current directory or any of its subdirectories and have the extension .Dockerfile
+  # Store the first file name in a variable
+  first_file=$(find $TARGET -name '*.Dockerfile' | head -n 1)
+  # Extract the Ext Bundle Version value from the first file
+  expected_version=$(grep -m 1 -oP "EXTENSION_BUNDLE_VERSION_V$VERSION=\K\S*" $first_file)
+  echo "Expected ExtensionBundleV$VERSION Version for all images in $TARGET : $expected_version from $first_file"
+  # Declare a boolean variable to indicate inconsistency
+  inconsistent=false
+  # Loop through the rest of the files and compare their values with the first one
+  for file in $(find $TARGET -name '*.Dockerfile'); do
+    # Extract the Ext Bundle value from the current file
+    current_version=$(grep -m 1 -oP "EXTENSION_BUNDLE_VERSION_V$VERSION=\K\S*" $file)
+    # Check if current_version is empty // Known files with no hostVersion *-core-tools.Dockerfile and *-build.Dockerfile
+    # Ext bundle not included in dotnet isolated images.
+    if [ -z "$current_version" ]; then
+      if [[ "$file" == *-core-tools* ]] || [[ "$file" == *-build* ]] || [[ "$file" == *dotnet-isolated* ]]; then
+        # Ignore the file
+        continue
+      else
+        # Print a message and set the inconsistency flag to true
+        echo "No EXTENSION_BUNDLE_VERSION_V$VERSION found in $file"
+        inconsistent=true
+      fi
+    fi
+    # Compare the values and print a message if they are different
+    if [ "$current_version" != "$expected_version" ]; then
+      echo "Mismatch found: $file has EXTENSION_BUNDLE_VERSION_V$VERSION=$current_version"
+      # Set the inconsistency flag to true
+      inconsistent=true
+    fi
+  done
+  # Check the inconsistency flag and exit with a 1 if it is true
+  if [ "$inconsistent" == "true" ]; then
+    echo "Inconsistency detected: EXTENSION_BUNDLE_VERSION_V$VERSION values are not the same across all files"
+    echo "$first_file has EXTENSION_BUNDLE_VERSION_V$VERSION=$expected_version"
+    exit 1
+  fi
+}
+VERSION=2
+check_extension_bundle
+VERSION=3
+check_extension_bundle
+VERSION=4
+check_extension_bundle
+
+exit 0

--- a/host/validate-hostversion.sh
+++ b/host/validate-hostversion.sh
@@ -31,7 +31,7 @@ for file in $(find $TARGET -name '*.Dockerfile'); do
   fi
   # Compare the values and print a message if they are different
   if [ "$current_version" != "$expected_host_version" ]; then
-    echo "Mismatch found: $file has HOST_VERSION=$current_version, while $first_file has HOST_VERSION=$first_version"
+    echo "Mismatch found: $file has HOST_VERSION=$current_version, while $first_file has HOST_VERSION=$expected_host_version"
     # Set the inconsistency flag to true
     inconsistent=true
   fi

--- a/host/validate-hostversion.sh
+++ b/host/validate-hostversion.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+if [ "$1" == "3" ]; then
+   echo -e "MajorVersion 3 detected. Verifying host_version in host/3.0/"
+   TARGET="./3.0"
+else 
+   echo -e "MajorVersion 4 detected. Verifying host_version in host/4/"
+   TARGET="./4"
+fi
+# Assume the docker files are in the current directory or any of its subdirectories and have the extension .Dockerfile
+# Store the first file name in a variable
+first_file=$(find $TARGET -name '*.Dockerfile' | head -n 1)
+# Extract the HOST_VERSION value from the first file
+expected_host_version=$(grep -m 1 -oP 'ARG HOST_VERSION=\K.*' $first_file)
+echo "Expected Host Version for all images in $TARGET : $expected_host_version"
+# Declare a boolean variable to indicate inconsistency
+inconsistent=false
+# Loop through the rest of the files and compare their values with the first one
+for file in $(find $TARGET -name '*.Dockerfile'); do
+  # Extract the HOST_VERSION value from the current file
+  current_version=$(grep -m 1 -oP 'ARG HOST_VERSION=\K.*' $file)
+  # Check if current_version is empty // Known files with no hostVersion *-core-tools.Dockerfile and *-build.Dockerfile
+  if [ -z "$current_version" ]; then
+    if [[ "$file" == *-core-tools* ]] || [[ "$file" == *-build* ]]; then
+      # Ignore the file
+      continue
+    else
+      # Print a message and set the inconsistency flag to true
+      echo "No HOST_VERSION found in $file"
+      inconsistent=true
+    fi
+  fi
+  # Compare the values and print a message if they are different
+  if [ "$current_version" != "$expected_host_version" ]; then
+    echo "Mismatch found: $file has HOST_VERSION=$current_version, while $first_file has HOST_VERSION=$first_version"
+    # Set the inconsistency flag to true
+    inconsistent=true
+  fi
+done
+# Check the inconsistency flag and exit with a 1 if it is true
+if [ "$inconsistent" == "true" ]; then
+  echo "Inconsistency detected: HOST_VERSION values are not the same across all files"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Recently we had Mariner images fall off of the Host Version wagon and get pinned accidentally to 4.26.0.  I wrote this script to force a future release to fail if any Dockerfile's are referencing a different HostVersion than the first Dockerfile picked up by the script.  That means that per Major version. Every image has have the same Host Version to allow us to release anything. 

EDIT : Added another script to test Extension Bundles version 2,3 4 in both host release versions. This one will fail v3 builds also!

NOTE : THIS WILL CAUSE V3 DEPLOYMENT TO FAIL AS WE HAVE OUT OF BAND VERSIONS IN THAT RELEASE.  This can be manually overridden in a situation where it is necessary. 

![image](https://github.com/Azure/azure-functions-docker/assets/46761504/032229ab-7c48-4023-84ce-b8a38865a917)
![image](https://github.com/Azure/azure-functions-docker/assets/46761504/ac06b09e-8d11-43bf-84a4-c982fefb5c31)
![image](https://github.com/Azure/azure-functions-docker/assets/46761504/4599ff05-4a8d-450e-aff0-ff4675a170d2)
