### PR TITLE
Update EnableWorkerIndexing on Dotnet-Isolated for 4.27.7.1 Release

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-composite.template
@@ -13,7 +13,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated-slim.Dockerfile
@@ -27,7 +27,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet-isolated/dotnet-isolated.Dockerfile
@@ -27,7 +27,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-composite.template
@@ -13,7 +13,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
@@ -27,7 +27,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet7-isolated/dotnet-isolated.Dockerfile
@@ -27,7 +27,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-composite.template
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-composite.template
@@ -11,6 +11,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing \
     ASPNETCORE_URLS=http://+:80
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
@@ -25,6 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing \
     ASPNETCORE_URLS=http://+:80
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
@@ -25,6 +25,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing \
     ASPNETCORE_URLS=http://+:80
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/mariner/dotnet/dotnet-isolated/dotnet7-isolated.Dockerfile
+++ b/host/4/mariner/dotnet/dotnet-isolated/dotnet7-isolated.Dockerfile
@@ -26,7 +26,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     FUNCTIONS_WORKER_RUNTIME=dotnet-isolated \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
-    ASPNETCORE_CONTENTROOT=/azure-functions-host
+    ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN dnf install -y glibc-devel


### PR DESCRIPTION
Cherry-pick of : https://github.com/Azure/azure-functions-docker/pull/997

This is on top 4.27.7 release. This will be a public image only release that will provide EnableWorkerIndexing in all dotnet-isolated images by default to support custom image /container customers for Dotnet-isolated.

This release was faulted during the release action so I need to run it again .  
This PR re-does : https://github.com/Azure/azure-functions-docker/pull/1001