### PR TITLE
Update dotnet8  EXPOSE port

### DIFF
--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated-slim.Dockerfile
@@ -28,6 +28,9 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureWebJobsFeatureFlags=EnableWorkerIndexing \
     ASPNETCORE_URLS=http://+:80
 
+# Default EXPOSE port inherited from Dotnet Base image has changed to 8080. Host still hosts on 80
+EXPOSE 80
+
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
     apt-get install -y libc-dev

--- a/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/amd64/dotnet/dotnet8-isolated/dotnet-isolated.Dockerfile
@@ -28,6 +28,9 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureWebJobsFeatureFlags=EnableWorkerIndexing \
     ASPNETCORE_URLS=http://+:80
 
+# Default EXPOSE port inherited from Dotnet Base image has changed to 8080. Host still hosts on 80
+EXPOSE 80
+
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
 RUN apt-get update && \
     apt-get install -y libc-dev


### PR DESCRIPTION
Common Docker image use cases take dependency on the EXPOSE docker configuration.  As part of the transition to dotnet8, we lost automatic inheritance of EXPOSE 80 and picked up EXPOSE 8080 from the new Dotnet 8 images. This causes unwanted issues with custom images for customers using dotnet8. The appservice variant of this image already exposed 80. This just takes that change to all dn8 images


