### PR TITLE
Removing pinning of the ODBC driver version and addressing security vulnerabilities of the Microsoft ODBC SQL Driver.

### DIFF
--- a/host/4/bullseye/amd64/python/python310/python310-buildenv.Dockerfile
+++ b/host/4/bullseye/amd64/python/python310/python310-buildenv.Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python310/python310-composite.template
+++ b/host/4/bullseye/amd64/python/python310/python310-composite.template
@@ -39,9 +39,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python310/python310-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python310/python310-slim.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python310/python310.Dockerfile
+++ b/host/4/bullseye/amd64/python/python310/python310.Dockerfile
@@ -77,9 +77,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python311/python311-buildenv.Dockerfile
+++ b/host/4/bullseye/amd64/python/python311/python311-buildenv.Dockerfile
@@ -28,11 +28,11 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
     echo 'deb http://security.debian.org/debian-security bullseye-security main' >> /etc/apt/sources.list && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18=18.2.2.1-1 mssql-tools18 &&\
+    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18 mssql-tools18 &&\
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g &&\
     apt-get install -y libglib2.0-0 libsm6 libxext6 libxrender-dev xvfb binutils\

--- a/host/4/bullseye/amd64/python/python311/python311-composite.template
+++ b/host/4/bullseye/amd64/python/python311/python311-composite.template
@@ -21,11 +21,11 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
     echo 'deb http://security.debian.org/debian-security bullseye-security main' >> /etc/apt/sources.list && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18=18.2.2.1-1 mssql-tools18 &&\
+    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18 mssql-tools18 &&\
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g &&\
     apt-get install -y libglib2.0-0 libsm6 libxext6 libxrender-dev xvfb binutils\

--- a/host/4/bullseye/amd64/python/python311/python311-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python311/python311-slim.Dockerfile
@@ -57,11 +57,11 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
     echo 'deb http://security.debian.org/debian-security bullseye-security main' >> /etc/apt/sources.list && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18=18.2.2.1-1 mssql-tools18 &&\
+    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18 mssql-tools18 &&\
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g &&\
     apt-get install -y libglib2.0-0 libsm6 libxext6 libxrender-dev xvfb binutils\

--- a/host/4/bullseye/amd64/python/python311/python311.Dockerfile
+++ b/host/4/bullseye/amd64/python/python311/python311.Dockerfile
@@ -57,11 +57,11 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
     # Needed for libss1.0.0 and in turn MS SQL
     echo 'deb http://security.debian.org/debian-security bullseye-security main' >> /etc/apt/sources.list && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18=18.2.2.1-1 mssql-tools18 &&\
+    ACCEPT_EULA=Y apt-get install -y unixodbc msodbcsql18 mssql-tools18 &&\
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g &&\
     apt-get install -y libglib2.0-0 libsm6 libxext6 libxrender-dev xvfb binutils\

--- a/host/4/bullseye/amd64/python/python37/python37-buildenv.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-buildenv.Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python37/python37-composite.template
+++ b/host/4/bullseye/amd64/python/python37/python37-composite.template
@@ -31,9 +31,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37-slim.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/amd64/python/python37/python37.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python38/python38-buildenv.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-buildenv.Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python38/python38-composite.template
+++ b/host/4/bullseye/amd64/python/python38/python38-composite.template
@@ -31,9 +31,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38-slim.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/amd64/python/python38/python38.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python39/python39-buildenv.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-buildenv.Dockerfile
@@ -28,9 +28,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python39/python39-composite.template
+++ b/host/4/bullseye/amd64/python/python39/python39-composite.template
@@ -31,9 +31,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39-slim.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \

--- a/host/4/bullseye/amd64/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/amd64/python/python39/python39.Dockerfile
@@ -68,9 +68,9 @@ RUN apt-get update && \
     apt-get update && apt-get install -y locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
     locale-gen && \
-    # install MS SQL related packages.pinned version in PR # 1012.
+    # install MS SQL related packages.
     apt-get update && \
-    apt-get install -y unixodbc msodbcsql17=17.10.4.1-1 mssql-tools && \
+    apt-get install -y unixodbc msodbcsql17 mssql-tools && \
     # .NET Core dependencies
     apt-get install -y --no-install-recommends ca-certificates \
     libc6 libgcc1 libgssapi-krb5-2 libicu67 libssl1.1 libstdc++6 zlib1g && \


### PR DESCRIPTION
Vulnerabilities : [Microsoft SQL Server, ODBC and OLE DB Driver for SQL Server Multiple Vulnerabilities for October 2023](https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2023-36785)

This pull request is reverting the pinned version of  Microsoft ODBC SQL Driver 17 and 18. The SQL team has introduced a new version of the ODBC driver that fixes the compatibility issues noted in [PR 1012](https://github.com/Azure/azure-functions-docker/pull/1012) and also resolves vulnerabilities associated with pinning previous versions.