### PR TITLE
Update AppService images to pull dotnet8 sdk 

### DIFF
--- a/host/4/bullseye/amd64/base/host.Dockerfile
+++ b/host/4/bullseye/amd64/base/host.Dockerfile
@@ -6,6 +6,12 @@ ARG HOST_VERSION
 ENV PublishWithAspNetCoreTargetManifest=false \
     DEBIAN_FRONTEND=noninteractive 
 
+RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-8.0
+
 RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \


### PR DESCRIPTION
Extend #1083 by adding dotnet8 to the sdk in the appservice images. 

