### PR TITLE
Add appservice tag for dedicated .NET 8 in proc image

### DIFF
--- a/host/4/publish-appservice-stage-sovereign-clouds.yml
+++ b/host/4/publish-appservice-stage-sovereign-clouds.yml
@@ -100,11 +100,11 @@ steps:
 
       - bash: |
           set -e
-          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice
+          docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice
           
-          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice-$(CloudName)-stage${{stage}}
+          docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice-$(CloudName)-stage${{stage}}
           
-          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice-$(CloudName)-stage${{stage}}
+          docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice-$(CloudName)-stage${{stage}}
           
           docker system prune -a -f
         displayName: tag and push dotnet8 in proc images for stage ${{stage}}

--- a/host/4/publish-appservice-stage.yml
+++ b/host/4/publish-appservice-stage.yml
@@ -53,11 +53,11 @@ steps:
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice
 
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice-stage$(StageNumber)
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice-stage$(StageNumber)
 
-      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice-stage$(StageNumber)
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice-stage$(StageNumber)
 
       docker system prune -a -f
     displayName: tag and push dotnet images

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -80,8 +80,13 @@ steps:
   - bash: |
       set -e
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice
+
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8 $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
+
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
 
       docker system prune -a -f
     displayName: tag and push dotnet images

--- a/host/4/publish.yml
+++ b/host/4/publish.yml
@@ -79,14 +79,14 @@ steps:
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8
-      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice
 
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8 $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0 $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice
 
-      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
-      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice
 
       docker system prune -a -f
     displayName: tag and push dotnet images

--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -65,8 +65,13 @@ steps:
   - bash: |
       set -e
       docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice
+
       docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8 $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
+
       docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
 
       docker system prune -a -f
     displayName: tag and push dotnet images

--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -64,14 +64,14 @@ steps:
 
   - bash: |
       set -e
-      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8
-      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0
+      docker pull $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice
 
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8 $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
-      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0 $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0
+      docker tag $SOURCE_REGISTRY/dotnet:$(PrivateVersion)-dotnet8.0-appservice $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice
 
-      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8
-      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8-appservice
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0
+      docker push $TARGET_REGISTRY/dotnet:$(TargetVersion)-dotnet8.0-appservice
 
       docker system prune -a -f
     displayName: tag and push dotnet images


### PR DESCRIPTION
This PR adds an appservice tag to the `publish.yml` and `republish.yml` files so that the tooling feed can consume these changes.

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

<!-- Thanks for using the checklist -->
