### PR TITLE
Update the pipeline, dotnet8 builds

### DIFF
--- a/host/4/bookworm/dotnet/dotnet8-appservice.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet8-appservice.Dockerfile
@@ -28,8 +28,6 @@ COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY install_ca_certificates.sh /opt/startup/
-RUN chmod +x /opt/startup/install_ca_certificates.sh && \
-    chmod +x /opt/startup/start.sh
 
 EXPOSE 2222 80
 

--- a/host/4/bookworm/dotnet/dotnet8-appservice.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet8-appservice.Dockerfile
@@ -28,6 +28,8 @@ COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY install_ca_certificates.sh /opt/startup/
+RUN chmod +x /opt/startup/install_ca_certificates.sh && \
+    chmod +x /opt/startup/start.sh
 
 EXPOSE 2222 80
 
@@ -37,4 +39,4 @@ RUN apt-get update && \
     chmod +x /azure-functions-host/start.sh && \
     chmod +x /opt/startup/install_ca_certificates.sh
 
-CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]
+ENTRYPOINT ["/azure-functions-host/start.sh"]

--- a/host/4/bookworm/dotnet/dotnet8.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet8.Dockerfile
@@ -25,5 +25,8 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     ASPNETCORE_URLS=http://+:80
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY install_ca_certificates.sh start_nonappservice.sh /opt/startup/
+RUN chmod +x /opt/startup/install_ca_certificates.sh && \
+    chmod +x /opt/startup/start_nonappservice.sh
 
-CMD [ "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost" ]
+CMD [ "/opt/startup/start_nonappservice.sh" ]

--- a/host/4/bookworm/dotnet/install_ca_certificates.sh
+++ b/host/4/bookworm/dotnet/install_ca_certificates.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Source and destination directories
+source_dir="/var/ssl/root"
+destination_dir="/usr/local/share/ca-certificates"
+need_certificate_update=false
+
+if [[ "$WEBSITES_INCLUDE_CLOUD_CERTS" == "true" ]]; then
+    echo "WEBSITES_INCLUDE_CLOUD_CERTS is set to true."
+    agc_source_dir="/usr/local/azure/certs"
+    if [ "$(ls "$agc_source_dir"/*.crt 2>/dev/null)" ]; then
+      # Copy CA certificates
+      cp "$agc_source_dir"/*.crt "$destination_dir"
+      need_certificate_update=true
+    fi
+else
+    echo "WEBSITES_INCLUDE_CLOUD_CERTS is not set to true."
+fi
+
+
+# Check if the source directory has no files with the .crt extension
+if [ "$(ls "$source_dir"/*.crt 2>/dev/null)" ]; then
+   
+   # Copy CA certificates
+   cp "$source_dir"/*.crt "$destination_dir"
+   
+   need_certificate_update=true
+
+   echo "CA certificates copied and updated successfully."
+fi
+
+if $need_certificate_update; then
+   # Run update-ca-certificates command to update the CA certificate store
+   update-ca-certificates
+fi

--- a/host/4/bookworm/dotnet/sshd_config
+++ b/host/4/bookworm/dotnet/sshd_config
@@ -1,0 +1,15 @@
+# This is ssh server systemwide configuration file.
+#
+# /etc/sshd_config
+
+Port 			SSH_PORT
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes

--- a/host/4/bookworm/dotnet/start.sh
+++ b/host/4/bookworm/dotnet/start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+export DOTNET_USE_POLLING_FILE_WATCHER=true
+
+if [ -z $PORT ]; then
+  export ASPNETCORE_URLS=http://*:80
+else
+  export ASPNETCORE_URLS=http://*:$PORT
+fi
+
+# Install ca-certificates
+source /opt/startup/install_ca_certificates.sh
+
+if [ -z $SSH_PORT ]; then
+  export SSH_PORT=2222
+fi
+
+if [ "$APPSVC_REMOTE_DEBUGGING" == "TRUE" ]; then
+    export languageWorkers__node__arguments="--inspect=0.0.0.0:$APPSVC_TUNNEL_PORT"
+    export languageWorkers__python__arguments="-m ptvsd --host localhost --port $APPSVC_TUNNEL_PORT"
+fi
+
+sed -i "s/SSH_PORT/$SSH_PORT/g" /etc/ssh/sshd_config
+
+service ssh start
+
+if [ -f /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost ]; then
+    /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost
+else
+    dotnet /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll
+fi

--- a/host/4/bookworm/dotnet/start_nonappservice.sh
+++ b/host/4/bookworm/dotnet/start_nonappservice.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+source /opt/startup/install_ca_certificates.sh
+
+/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost

--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -321,13 +321,13 @@ steps:
   - bash: |
       set -e
       docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node22
-      docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node22-slim
+      docker pull $SOURCE_REGISTRY/node:$(PrivateVersion)-node22-appservice
 
       docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node22 $TARGET_REGISTRY/node:$(TargetVersion)-node22
-      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node22-slim $TARGET_REGISTRY/node:$(TargetVersion)-node22-slim
+      docker tag $SOURCE_REGISTRY/node:$(PrivateVersion)-node22-appservice $TARGET_REGISTRY/node:$(TargetVersion)-node22-appservice
 
       docker push $TARGET_REGISTRY/node:$(TargetVersion)-node22
-      docker push $TARGET_REGISTRY/node:$(TargetVersion)-node22-slim
+      docker push $TARGET_REGISTRY/node:$(TargetVersion)-node22-appservice
 
 
       docker system prune -a -f


### PR DESCRIPTION
Building dotnet8 is broken because of an issue with merging in May.  This updates the state of the dotnet8 images to include the shell scripts that it needs. It also sets up the node republish pipeline to work better. 