### PR TITLE
Fix dotnet8.0 image tag build

### DIFF
--- a/host/4/dotnet-build.yml
+++ b/host/4/dotnet-build.yml
@@ -115,7 +115,7 @@ jobs:
           dotnetVersion: "dotnet8-appservice"
           dockerfilePath: "host/4/bookworm/dotnet/"
           dockerImagePath: "dotnet"
-          dockerImageName: "-dotnet8.0appservice"
+          dockerImageName: "-dotnet8.0-appservice"
         _bookworm-net-9:
           dotnetVersion: "dotnet9-appservice"
           dockerfilePath: "host/4/bookworm/dotnet-isolated/"


### PR DESCRIPTION
Fix publish errors - https://azure-functions.visualstudio.com/azure-functions-docker/_build/results?buildId=26163&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=ffe5b61a-4918-59e6-2d77-95255068933d due to invalid image tag in build