### PR TITLE
[Release4.36]Update OOP languages to host 4.1036.0

### DIFF
--- a/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated-appservice.Dockerfile
+++ b/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated-appservice.Dockerfile
@@ -1,5 +1,5 @@
 
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated-slim.Dockerfile
+++ b/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated.Dockerfile
+++ b/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bookworm/dotnet-isolated/dotnet9-isolated/dotnet9-appservice.Dockerfile
+++ b/host/4/bookworm/dotnet-isolated/dotnet9-isolated/dotnet9-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bookworm/java/java21/java21-appservice.Dockerfile
+++ b/host/4/bookworm/java/java21/java21-appservice.Dockerfile
@@ -1,7 +1,7 @@
 ARG JAVA_VERSION=21.0.1
 ARG JAVA_HOME=/usr/lib/jvm/msft-21-x64
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 COPY --from=mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 [ "/usr/share/dotnet", "/usr/share/dotnet" ]

--- a/host/4/bookworm/java/java21/java21-slim.Dockerfile
+++ b/host/4/bookworm/java/java21/java21-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=21.0.1
 ARG JAVA_HOME=/usr/lib/jvm/msft-21-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image

--- a/host/4/bookworm/java/java21/java21.Dockerfile
+++ b/host/4/bookworm/java/java21/java21.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=21.0.1
 ARG JAVA_HOME=/usr/lib/jvm/msft-21-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image

--- a/host/4/bookworm/node/node22/node22-appservice.Dockerfile
+++ b/host/4/bookworm/node/node22/node22-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS dn8-sdk-image
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/bookworm/node/node22/node22.Dockerfile
+++ b/host/4/bookworm/node/node22/node22.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS dn8-sdk-image
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/bookworm/powershell/powershell74/powershell74-appservice.Dockerfile
+++ b/host/4/bookworm/powershell/powershell74/powershell74-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bookworm/powershell/powershell74/powershell74-slim.Dockerfile
+++ b/host/4/bookworm/powershell/powershell74/powershell74-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bookworm/powershell/powershell74/powershell74.Dockerfile
+++ b/host/4/bookworm/powershell/powershell74/powershell74.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/base/host.Dockerfile
+++ b/host/4/bullseye/base/host.Dockerfile
@@ -1,4 +1,4 @@
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/bullseye/dotnet-isolated/dotnet6-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/dotnet-isolated/dotnet6-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/dotnet-isolated/dotnet6-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/dotnet-isolated/dotnet6-isolated/dotnet-isolated.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/dotnet-isolated/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
+++ b/host/4/bullseye/dotnet-isolated/dotnet7-isolated/dotnet-isolated-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/dotnet-isolated/dotnet7-isolated/dotnet-isolated.Dockerfile
+++ b/host/4/bullseye/dotnet-isolated/dotnet7-isolated/dotnet-isolated.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/java/java11/java11-slim.Dockerfile
+++ b/host/4/bullseye/java/java11/java11-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=11.0.21
 ARG JAVA_HOME=/usr/lib/jvm/msft-11-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/java/java11/java11.Dockerfile
+++ b/host/4/bullseye/java/java11/java11.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=11.0.21
 ARG JAVA_HOME=/usr/lib/jvm/msft-11-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/java/java17/java17-slim.Dockerfile
+++ b/host/4/bullseye/java/java17/java17-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=17.0.9
 ARG JAVA_HOME=/usr/lib/jvm/msft-17-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/java/java17/java17.Dockerfile
+++ b/host/4/bullseye/java/java17/java17.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=17.0.9
 ARG JAVA_HOME=/usr/lib/jvm/msft-17-x64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image

--- a/host/4/bullseye/java/java8/java8-slim.Dockerfile
+++ b/host/4/bullseye/java/java8/java8-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=8u392b08
 ARG JDK_NAME=jdk8u392-b08
 ARG JAVA_HOME=/usr/lib/jvm/adoptium-8-x64

--- a/host/4/bullseye/java/java8/java8.Dockerfile
+++ b/host/4/bullseye/java/java8/java8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 ARG JAVA_VERSION=8u392b08
 ARG JDK_NAME=jdk8u392-b08
 ARG JAVA_HOME=/usr/lib/jvm/adoptium-8-x64

--- a/host/4/bullseye/node/node14/node14-slim.Dockerfile
+++ b/host/4/bullseye/node/node14/node14-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node14/node14.Dockerfile
+++ b/host/4/bullseye/node/node14/node14.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node16/node16-slim.Dockerfile
+++ b/host/4/bullseye/node/node16/node16-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node16/node16.Dockerfile
+++ b/host/4/bullseye/node/node16/node16.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node18/node18-slim.Dockerfile
+++ b/host/4/bullseye/node/node18/node18-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node18/node18.Dockerfile
+++ b/host/4/bullseye/node/node18/node18.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node20/node20-slim.Dockerfile
+++ b/host/4/bullseye/node/node20/node20-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/node/node20/node20.Dockerfile
+++ b/host/4/bullseye/node/node20/node20.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/powershell/powershell70/powershell70-slim.Dockerfile
+++ b/host/4/bullseye/powershell/powershell70/powershell70-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/powershell/powershell70/powershell70.Dockerfile
+++ b/host/4/bullseye/powershell/powershell70/powershell70.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/powershell/powershell72/powershell72-slim.Dockerfile
+++ b/host/4/bullseye/powershell/powershell72/powershell72-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/powershell/powershell72/powershell72.Dockerfile
+++ b/host/4/bullseye/powershell/powershell72/powershell72.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python310/python310-slim.Dockerfile
+++ b/host/4/bullseye/python/python310/python310-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python310/python310.Dockerfile
+++ b/host/4/bullseye/python/python310/python310.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python311/python311-slim.Dockerfile
+++ b/host/4/bullseye/python/python311/python311-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python311/python311.Dockerfile
+++ b/host/4/bullseye/python/python311/python311.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python37/python37-slim.Dockerfile
+++ b/host/4/bullseye/python/python37/python37-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python37/python37.Dockerfile
+++ b/host/4/bullseye/python/python37/python37.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python38/python38-slim.Dockerfile
+++ b/host/4/bullseye/python/python38/python38-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python38/python38.Dockerfile
+++ b/host/4/bullseye/python/python38/python38.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python39/python39-slim.Dockerfile
+++ b/host/4/bullseye/python/python39/python39-slim.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/python/python39/python39.Dockerfile
+++ b/host/4/bullseye/python/python39/python39.Dockerfile
@@ -4,7 +4,7 @@
 #-------------------------------------------------------------------------------------------------------------
 
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/mariner/dotnet-isolated/dotnet7-isolated-mariner.Dockerfile
+++ b/host/4/mariner/dotnet-isolated/dotnet7-isolated-mariner.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS dn8-sdk-image
 FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/mariner/dotnet-isolated/dotnet8-isolated-mariner.Dockerfile
+++ b/host/4/mariner/dotnet-isolated/dotnet8-isolated-mariner.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.1035.1
+ARG HOST_VERSION=4.1036.0
 FROM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS dn8-sdk-image
 FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS sdk-image 
 ARG HOST_VERSION


### PR DESCRIPTION
Update OOP images to Hoser version https://github.com/Azure/azure-functions-host/tree/v4.1036.0?search=1