### PR TITLE
Remove non-existing tags from republish

### DIFF
--- a/host/4/republish.yml
+++ b/host/4/republish.yml
@@ -616,17 +616,14 @@ jobs:
         docker system prune -a -f
 
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12
-        docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12-slim
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12-buildenv
         docker pull $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12-appservice
 
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12 $TARGET_REGISTRY/python:$(TargetVersion)-python3.12
-        docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12-slim $TARGET_REGISTRY/python:$(TargetVersion)-python3.12-slim
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12-buildenv $TARGET_REGISTRY/python:$(TargetVersion)-python3.12-buildenv
         docker tag $SOURCE_REGISTRY/python:$(PrivateVersion)-python3.12-appservice $TARGET_REGISTRY/python:$(TargetVersion)-python3.12-appservice
 
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.12
-        docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.12-slim
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.12-buildenv
         docker push $TARGET_REGISTRY/python:$(TargetVersion)-python3.12-appservice
 


### PR DESCRIPTION
Fix https://github.com/Azure/azure-functions-docker/actions/runs/10840914187/job/30084107496

```
Switched to a new branch 'refresh/4.36.0.1-refresh'
MajorVersion 4 detected. Verifying pipelines in host/4/
/python:$(TargetVersion)-python3.12-slim
Republish and Publish pipelines inconsistent. Other than the /base image all pipelines should publish the same non-quickstart images. The following differences exist for images between the pipelines: 
/python:$(TargetVersion)-python3.12-slim
```