### PR TITLE
[.Net6Inproc]buildcmd with MinorVersionPrefix=6

### DIFF
--- a/host/4/bullseye/dotnet-inproc/dotnet-appservice.Dockerfile
+++ b/host/4/bullseye/dotnet-inproc/dotnet-appservice.Dockerfile
@@ -15,7 +15,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 --framework net6.0 --self-contained && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 --framework net6.0 --self-contained /p:MinorVersionPrefix=6 && \
     
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src

--- a/host/4/bullseye/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/dotnet-inproc/dotnet.Dockerfile
@@ -15,7 +15,7 @@ RUN BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) && \
     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host && \
     cd /src/azure-functions-host && \
     HOST_COMMIT=$(git rev-list -1 HEAD) && \
-    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 --framework net6.0 --self-contained && \
+    dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host --runtime linux-x64 --framework net6.0 --self-contained /p:MinorVersionPrefix=6 && \
     
     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers && \
     rm -rf /root/.local /root/.nuget /src


### PR DESCRIPTION
https://github.com/Azure/azure-functions-docker/blob/e8a322fa1554b614088b540a463575ec41734242/host/4/bullseye/dotnet-inproc/dotnet-appservice.Dockerfile#L18

Compare to how host is buit in the host repo - [azure-functions-host/build/build-extensions.ps1 at 91e0bf7eca21fb9bb380450cf9d148745b0f4870 · Azure/azure-functions-host (github.com)](https://github.com/Azure/azure-functions-host/blob/91e0bf7eca21fb9bb380450cf9d148745b0f4870/build/build-extensions.ps1#L4)

Build cmd in the docker image is missing - /p:MinorVersionPrefix=6https://github.com/Azure/azure-functions-docker/blob/e8a322fa1554b614088b540a463575ec41734242/host/4/bullseye/dotnet-inproc/dotnet-appservice.Dockerfile#L18

Compare to how host is buit in the host repo - [azure-functions-host/build/build-extensions.ps1 at 91e0bf7eca21fb9bb380450cf9d148745b0f4870 · Azure/azure-functions-host (github.com)](https://github.com/Azure/azure-functions-host/blob/91e0bf7eca21fb9bb380450cf9d148745b0f4870/build/build-extensions.ps1#L4)

Build cmd in the docker image is missing - /p:MinorVersionPrefix=6