### PR TITLE
Enforcing Min extension bundle versions for node22, java21,python3.12 and  dotnet9-isolated

### DIFF
--- a/host/4/bookworm/dotnet-isolated/dotnet9-isolated/FunctionHostingEnvironmentConfig.json
+++ b/host/4/bookworm/dotnet-isolated/dotnet9-isolated/FunctionHostingEnvironmentConfig.json
@@ -1,0 +1,135 @@
+{
+    "HostingEnvironmentConfig": {
+      "extensionRequirements": {
+        "bundles": [
+          {
+            "id": "Microsoft.Azure.Functions.ExtensionBundle",
+            "minimumVersion": "4.12.0"
+          }
+        ],
+        "types": [
+          {
+            "name": "NetheriteProviderStartup",
+            "assemblyName": "DurableTask.Netherite.AzureFunctions",
+            "minimumAssemblyVersion": "1.0.0.0",
+            "minimumAssemblyFileVersion": "1.4.0.4129",
+            "packageName": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
+            "minimumPackageVersion": "1.4.0"
+          },
+          {
+            "name": "SqlDurabilityProviderStartup",
+            "assemblyName": "DurableTask.SqlServer.AzureFunctions",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.DurableTask.SqlServer.AzureFunctions",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "CosmosDBWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumAssemblyVersion": "4.4.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumPackageVersion": "4.4.0"
+          },
+          {
+            "name": "DurableTaskWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumAssemblyVersion": "2.0.0.0",
+            "MinimumAssemblyFileVersion": "2.12.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumPackageVersion": "2.12.0"
+          },
+          {
+            "name": "EventGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumAssemblyVersion": "3.3.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumPackageVersion": "3.3.0"
+          },
+          {
+            "name": "EventHubsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumAssemblyVersion": "5.5.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumPackageVersion": "5.5.0"
+          },
+          {
+            "name": "KafkaWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumAssemblyVersion": "3.9.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumPackageVersion": "3.9.0"
+          },
+          {
+            "name": "RabbitMQWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumAssemblyVersion": "2.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumPackageVersion": "2.0.3"
+          },
+          {
+            "name": "SendGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumAssemblyVersion": "3.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumPackageVersion": "3.0.3"
+          },
+          {
+            "name": "ServiceBusWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumAssemblyVersion": "5.12.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumPackageVersion": "5.12.0"
+          },
+          {
+            "name": "SignalRWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumAssemblyVersion": "1.11.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumPackageVersion": "1.11.2"
+          },
+          {
+            "name": "SqlBindingStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumAssemblyVersion": "3.0.461.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumPackageVersion": "3.0.461"
+          },
+          {
+            "name": "AzureStorageBlobsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumAssemblyVersion": "5.2.1.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumPackageVersion": "5.2.1"
+          },
+          {
+            "name": "AzureStorageQueuesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumAssemblyVersion": "5.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumPackageVersion": "5.2.0"
+          },
+          {
+            "name": "AzureTablesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "TwilioWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumAssemblyVersion": "3.0.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumPackageVersion": "3.0.2"
+          },
+          {
+            "name": "WebPubSubWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumAssemblyVersion": "1.7.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumPackageVersion": "1.7.0"
+          }
+        ]
+      }
+    }
+  }

--- a/host/4/bookworm/dotnet-isolated/dotnet9-isolated/dotnet9-isolated-appservice.Dockerfile
+++ b/host/4/bookworm/dotnet-isolated/dotnet9-isolated/dotnet9-isolated-appservice.Dockerfile
@@ -23,12 +23,14 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     AzureWebJobsFeatureFlags=EnableWorkerIndexing \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY install_ca_certificates.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 
 EXPOSE 2222 80
 

--- a/host/4/bookworm/dotnet-isolated/dotnet9-isolated/dotnet9-isolated.Dockerfile
+++ b/host/4/bookworm/dotnet-isolated/dotnet9-isolated/dotnet9-isolated.Dockerfile
@@ -23,6 +23,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     AzureWebJobsFeatureFlags=EnableWorkerIndexing \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 # Default EXPOSE port inherited from Dotnet Base image has changed to 8080. Host still hosts on 80
@@ -35,6 +36,7 @@ RUN apt-get update && \
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
 
 COPY install_ca_certificates.sh start_nonappservice.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 RUN chmod +x /opt/startup/install_ca_certificates.sh && \
     chmod +x /opt/startup/start_nonappservice.sh
 

--- a/host/4/bookworm/java/java21/FunctionHostingEnvironmentConfig.json
+++ b/host/4/bookworm/java/java21/FunctionHostingEnvironmentConfig.json
@@ -1,0 +1,135 @@
+{
+    "HostingEnvironmentConfig": {
+      "extensionRequirements": {
+        "bundles": [
+          {
+            "id": "Microsoft.Azure.Functions.ExtensionBundle",
+            "minimumVersion": "4.12.0"
+          }
+        ],
+        "types": [
+          {
+            "name": "NetheriteProviderStartup",
+            "assemblyName": "DurableTask.Netherite.AzureFunctions",
+            "minimumAssemblyVersion": "1.0.0.0",
+            "minimumAssemblyFileVersion": "1.4.0.4129",
+            "packageName": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
+            "minimumPackageVersion": "1.4.0"
+          },
+          {
+            "name": "SqlDurabilityProviderStartup",
+            "assemblyName": "DurableTask.SqlServer.AzureFunctions",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.DurableTask.SqlServer.AzureFunctions",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "CosmosDBWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumAssemblyVersion": "4.4.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumPackageVersion": "4.4.0"
+          },
+          {
+            "name": "DurableTaskWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumAssemblyVersion": "2.0.0.0",
+            "MinimumAssemblyFileVersion": "2.12.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumPackageVersion": "2.12.0"
+          },
+          {
+            "name": "EventGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumAssemblyVersion": "3.3.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumPackageVersion": "3.3.0"
+          },
+          {
+            "name": "EventHubsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumAssemblyVersion": "5.5.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumPackageVersion": "5.5.0"
+          },
+          {
+            "name": "KafkaWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumAssemblyVersion": "3.9.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumPackageVersion": "3.9.0"
+          },
+          {
+            "name": "RabbitMQWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumAssemblyVersion": "2.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumPackageVersion": "2.0.3"
+          },
+          {
+            "name": "SendGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumAssemblyVersion": "3.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumPackageVersion": "3.0.3"
+          },
+          {
+            "name": "ServiceBusWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumAssemblyVersion": "5.12.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumPackageVersion": "5.12.0"
+          },
+          {
+            "name": "SignalRWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumAssemblyVersion": "1.11.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumPackageVersion": "1.11.2"
+          },
+          {
+            "name": "SqlBindingStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumAssemblyVersion": "3.0.461.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumPackageVersion": "3.0.461"
+          },
+          {
+            "name": "AzureStorageBlobsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumAssemblyVersion": "5.2.1.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumPackageVersion": "5.2.1"
+          },
+          {
+            "name": "AzureStorageQueuesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumAssemblyVersion": "5.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumPackageVersion": "5.2.0"
+          },
+          {
+            "name": "AzureTablesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "TwilioWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumAssemblyVersion": "3.0.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumPackageVersion": "3.0.2"
+          },
+          {
+            "name": "WebPubSubWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumAssemblyVersion": "1.7.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumPackageVersion": "1.7.0"
+          }
+        ]
+      }
+    }
+  }

--- a/host/4/bookworm/java/java21/java21-appservice.Dockerfile
+++ b/host/4/bookworm/java/java21/java21-appservice.Dockerfile
@@ -36,6 +36,7 @@ COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY install_ca_certificates.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 
 EXPOSE 2222 80
 
@@ -46,6 +47,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=${JAVA_HOME} \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157

--- a/host/4/bookworm/java/java21/java21-slim.Dockerfile
+++ b/host/4/bookworm/java/java21/java21-slim.Dockerfile
@@ -44,6 +44,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=${JAVA_HOME} \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
@@ -59,6 +60,7 @@ COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java
 COPY --from=runtime-image [ "${JAVA_HOME}", "${JAVA_HOME}" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY install_ca_certificates.sh start_nonappservice.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 RUN chmod +x /opt/startup/install_ca_certificates.sh && \
     chmod +x /opt/startup/start_nonappservice.sh
 

--- a/host/4/bookworm/java/java21/java21.Dockerfile
+++ b/host/4/bookworm/java/java21/java21.Dockerfile
@@ -44,6 +44,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     JAVA_HOME=${JAVA_HOME} \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 # Fix from https://github.com/GoogleCloudPlatform/google-cloud-dotnet-powerpack/issues/22#issuecomment-729895157
@@ -59,6 +60,7 @@ COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java
 COPY --from=runtime-image [ "${JAVA_HOME}", "${JAVA_HOME}" ]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY install_ca_certificates.sh start_nonappservice.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 RUN chmod +x /opt/startup/install_ca_certificates.sh && \
     chmod +x /opt/startup/start_nonappservice.sh
 

--- a/host/4/bookworm/node/node22/FunctionHostingEnvironmentConfig.json
+++ b/host/4/bookworm/node/node22/FunctionHostingEnvironmentConfig.json
@@ -1,0 +1,135 @@
+{
+    "HostingEnvironmentConfig": {
+      "extensionRequirements": {
+        "bundles": [
+          {
+            "id": "Microsoft.Azure.Functions.ExtensionBundle",
+            "minimumVersion": "4.12.0"
+          }
+        ],
+        "types": [
+          {
+            "name": "NetheriteProviderStartup",
+            "assemblyName": "DurableTask.Netherite.AzureFunctions",
+            "minimumAssemblyVersion": "1.0.0.0",
+            "minimumAssemblyFileVersion": "1.4.0.4129",
+            "packageName": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
+            "minimumPackageVersion": "1.4.0"
+          },
+          {
+            "name": "SqlDurabilityProviderStartup",
+            "assemblyName": "DurableTask.SqlServer.AzureFunctions",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.DurableTask.SqlServer.AzureFunctions",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "CosmosDBWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumAssemblyVersion": "4.4.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumPackageVersion": "4.4.0"
+          },
+          {
+            "name": "DurableTaskWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumAssemblyVersion": "2.0.0.0",
+            "MinimumAssemblyFileVersion": "2.12.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumPackageVersion": "2.12.0"
+          },
+          {
+            "name": "EventGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumAssemblyVersion": "3.3.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumPackageVersion": "3.3.0"
+          },
+          {
+            "name": "EventHubsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumAssemblyVersion": "5.5.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumPackageVersion": "5.5.0"
+          },
+          {
+            "name": "KafkaWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumAssemblyVersion": "3.9.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumPackageVersion": "3.9.0"
+          },
+          {
+            "name": "RabbitMQWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumAssemblyVersion": "2.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumPackageVersion": "2.0.3"
+          },
+          {
+            "name": "SendGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumAssemblyVersion": "3.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumPackageVersion": "3.0.3"
+          },
+          {
+            "name": "ServiceBusWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumAssemblyVersion": "5.12.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumPackageVersion": "5.12.0"
+          },
+          {
+            "name": "SignalRWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumAssemblyVersion": "1.11.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumPackageVersion": "1.11.2"
+          },
+          {
+            "name": "SqlBindingStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumAssemblyVersion": "3.0.461.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumPackageVersion": "3.0.461"
+          },
+          {
+            "name": "AzureStorageBlobsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumAssemblyVersion": "5.2.1.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumPackageVersion": "5.2.1"
+          },
+          {
+            "name": "AzureStorageQueuesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumAssemblyVersion": "5.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumPackageVersion": "5.2.0"
+          },
+          {
+            "name": "AzureTablesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "TwilioWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumAssemblyVersion": "3.0.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumPackageVersion": "3.0.2"
+          },
+          {
+            "name": "WebPubSubWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumAssemblyVersion": "1.7.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumPackageVersion": "1.7.0"
+          }
+        ]
+      }
+    }
+  }

--- a/host/4/bookworm/node/node22/node22-appservice.Dockerfile
+++ b/host/4/bookworm/node/node22/node22-appservice.Dockerfile
@@ -34,6 +34,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 
@@ -43,6 +44,7 @@ COPY --from=runtime-image [ "/workers/node", "/azure-functions-host/workers/node
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
 COPY install_ca_certificates.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 
 RUN apt-get update && \
     apt-get install -y curl gnupg && \

--- a/host/4/bookworm/node/node22/node22.Dockerfile
+++ b/host/4/bookworm/node/node22/node22.Dockerfile
@@ -27,6 +27,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim-amd64
 ARG HOST_VERSION
 
 COPY install_ca_certificates.sh start_nonappservice.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 RUN chmod +x /opt/startup/install_ca_certificates.sh && \
     chmod +x /opt/startup/start_nonappservice.sh
 
@@ -36,6 +37,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     ASPNETCORE_URLS=http://+:80
 
 COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]

--- a/host/4/bookworm/python/python312/FunctionHostingEnvironmentConfig.json
+++ b/host/4/bookworm/python/python312/FunctionHostingEnvironmentConfig.json
@@ -1,0 +1,135 @@
+{
+    "HostingEnvironmentConfig": {
+      "extensionRequirements": {
+        "bundles": [
+          {
+            "id": "Microsoft.Azure.Functions.ExtensionBundle",
+            "minimumVersion": "4.12.0"
+          }
+        ],
+        "types": [
+          {
+            "name": "NetheriteProviderStartup",
+            "assemblyName": "DurableTask.Netherite.AzureFunctions",
+            "minimumAssemblyVersion": "1.0.0.0",
+            "minimumAssemblyFileVersion": "1.4.0.4129",
+            "packageName": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
+            "minimumPackageVersion": "1.4.0"
+          },
+          {
+            "name": "SqlDurabilityProviderStartup",
+            "assemblyName": "DurableTask.SqlServer.AzureFunctions",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.DurableTask.SqlServer.AzureFunctions",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "CosmosDBWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumAssemblyVersion": "4.4.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
+            "minimumPackageVersion": "4.4.0"
+          },
+          {
+            "name": "DurableTaskWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumAssemblyVersion": "2.0.0.0",
+            "MinimumAssemblyFileVersion": "2.12.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+            "minimumPackageVersion": "2.12.0"
+          },
+          {
+            "name": "EventGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumAssemblyVersion": "3.3.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
+            "minimumPackageVersion": "3.3.0"
+          },
+          {
+            "name": "EventHubsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumAssemblyVersion": "5.5.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
+            "minimumPackageVersion": "5.5.0"
+          },
+          {
+            "name": "KafkaWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumAssemblyVersion": "3.9.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+            "minimumPackageVersion": "3.9.0"
+          },
+          {
+            "name": "RabbitMQWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumAssemblyVersion": "2.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.RabbitMQ",
+            "minimumPackageVersion": "2.0.3"
+          },
+          {
+            "name": "SendGridWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumAssemblyVersion": "3.0.3.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SendGrid",
+            "minimumPackageVersion": "3.0.3"
+          },
+          {
+            "name": "ServiceBusWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumAssemblyVersion": "5.12.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
+            "minimumPackageVersion": "5.12.0"
+          },
+          {
+            "name": "SignalRWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumAssemblyVersion": "1.11.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
+            "minimumPackageVersion": "1.11.2"
+          },
+          {
+            "name": "SqlBindingStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumAssemblyVersion": "3.0.461.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Sql",
+            "minimumPackageVersion": "3.0.461"
+          },
+          {
+            "name": "AzureStorageBlobsWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumAssemblyVersion": "5.2.1.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
+            "minimumPackageVersion": "5.2.1"
+          },
+          {
+            "name": "AzureStorageQueuesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumAssemblyVersion": "5.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
+            "minimumPackageVersion": "5.2.0"
+          },
+          {
+            "name": "AzureTablesWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumAssemblyVersion": "1.2.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Tables",
+            "minimumPackageVersion": "1.2.0"
+          },
+          {
+            "name": "TwilioWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumAssemblyVersion": "3.0.2.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.Twilio",
+            "minimumPackageVersion": "3.0.2"
+          },
+          {
+            "name": "WebPubSubWebJobsStartup",
+            "assemblyName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumAssemblyVersion": "1.7.0.0",
+            "packageName": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
+            "minimumPackageVersion": "1.7.0"
+          }
+        ]
+      }
+    }
+  }

--- a/host/4/bookworm/python/python312/python312-appservice.Dockerfile
+++ b/host/4/bookworm/python/python312/python312-appservice.Dockerfile
@@ -37,6 +37,7 @@ COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY install_ca_certificates.sh /opt/startup/
 COPY sshd_config /etc/ssh/
 COPY start.sh /azure-functions-host/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 RUN chmod +x /opt/startup/install_ca_certificates.sh && \
     chmod +x /azure-functions-host/start.sh
 
@@ -87,6 +88,7 @@ ENV LANG=C.UTF-8 \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     LD_LIBRARY_PATH=/opt/python/3.12/lib:$LD_LIBRARY_PATH \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     FUNCTIONS_WORKER_RUNTIME_VERSION=3.12 
 
 RUN apt-get update && \

--- a/host/4/bookworm/python/python312/python312.Dockerfile
+++ b/host/4/bookworm/python/python312/python312.Dockerfile
@@ -35,6 +35,7 @@ ARG HOST_VERSION
 COPY --from=runtime-image ["/azure-functions-host", "/azure-functions-host"]
 COPY --from=runtime-image [ "/FuncExtensionBundles", "/FuncExtensionBundles" ]
 COPY install_ca_certificates.sh start_nonappservice.sh /opt/startup/
+COPY FunctionHostingEnvironmentConfig.json /local/FunctionHostingEnvironmentConfig.json
 RUN chmod +x /opt/startup/install_ca_certificates.sh && \
     chmod +x /opt/startup/start_nonappservice.sh
 
@@ -85,6 +86,7 @@ ENV LANG=C.UTF-8 \
     HOST_VERSION=${HOST_VERSION} \
     ASPNETCORE_CONTENTROOT=/azure-functions-host \
     LD_LIBRARY_PATH=/opt/python/3.12/lib:$LD_LIBRARY_PATH \
+    FUNCTIONS_HOSTING_ENVIRONMENT_CONFIG_FILE_PATH=/local/FunctionHostingEnvironmentConfig.json \
     FUNCTIONS_WORKER_RUNTIME_VERSION=3.12 
 
 CMD [ "/opt/startup/start_nonappservice.sh" ]


### PR DESCRIPTION
New runtimes will support V4 bundles only; 
Related PR in Host - https://github.com/Azure/azure-functions-host/pull/10290/files