### PR TITLE
Upgrading host version for inproc images

### DIFF
--- a/host/4/bookworm/dotnet/dotnet6.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet6.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.636.0
+ARG HOST_VERSION=4.636.2
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS dn8-sdk-image
 FROM mcr.microsoft.com/dotnet/sdk:6.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION

--- a/host/4/bookworm/dotnet/dotnet8-appservice.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet8-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.836.0
+ARG HOST_VERSION=4.836.2
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bookworm/dotnet/dotnet8.Dockerfile
+++ b/host/4/bookworm/dotnet/dotnet8.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.836.0
+ARG HOST_VERSION=4.836.2
 FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/dotnet-inproc/dotnet-appservice.Dockerfile
+++ b/host/4/bullseye/dotnet-inproc/dotnet-appservice.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.636.0
+ARG HOST_VERSION=4.636.2
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/dotnet-inproc/dotnet-slim.Dockerfile
+++ b/host/4/bullseye/dotnet-inproc/dotnet-slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.635.0
+ARG HOST_VERSION=4.636.2
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 

--- a/host/4/bullseye/dotnet-inproc/dotnet.Dockerfile
+++ b/host/4/bullseye/dotnet-inproc/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 # Build the runtime from source
-ARG HOST_VERSION=4.636.0
+ARG HOST_VERSION=4.636.2
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS runtime-image
 ARG HOST_VERSION
 


### PR DESCRIPTION
4.836.2 : [Release 4.836.2 · Azure/azure-functions-host](https://github.com/Azure/azure-functions-host/releases/tag/v4.836.2)
4.636.2 : [Release 4.636.2 · Azure/azure-functions-host](https://github.com/Azure/azure-functions-host/releases/tag/v4.636.2)