### PR TITLE
[Draft] Add GitHub Actions schedule to ensure images are refreshed every 2 weeks

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,6 +1,11 @@
 name: Refresh Non-appservice Images
 
 on:
+  # Images are refreshed at least once every two weeks:
+  schedule:
+  - cron: "0 */336 * * 1" # every 336 hours (14 days) on Mondays
+  
+  # Also enable the custom 'refresh' trigger:
   repository_dispatch:
     types: [refresh]
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

Add a `schedule` trigger to the `refresh` workflow so that images are refreshed at least once every two weeks. This is the cadence that is documented in the wiki ([1](https://github.com/Azure/azure-functions-docker/wiki/Building-functions-base-images-on-demand), [2](https://github.com/Azure/azure-functions-docker/wiki/Functions-image-release-process)).

As noted in several comments ([1](https://github.com/Azure/azure-functions-docker/issues/1185#issuecomment-2609749567), [2](https://github.com/Azure/azure-functions-docker/issues/1213#issuecomment-2791108334)), this cadence has not been met in the past.

---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] ~~New Unit tests were added for the changes made and CI is passing.~~

<!-- Thanks for using the checklist -->
